### PR TITLE
Update css to use -gtk-icon-shadow

### DIFF
--- a/data/Greeter.css
+++ b/data/Greeter.css
@@ -34,7 +34,7 @@
     text-shadow:
         0 0 2px alpha (#000, 0.3),
         0 1px 2px alpha (#000, 0.6);
-    icon-shadow:
+    -gtk-icon-shadow:
         0 0 2px alpha (#000, 0.3),
         0 1px 2px alpha (#000, 0.6);
 }


### PR DESCRIPTION
LightDM complains about the icon shadow property being renamed 

`Theme parsing error: Greeter.css:37:15: The 'icon-shadow' property has been renamed to '-gtk-icon-shadow'`