### PR TITLE
Fix incorrect compositor build_rpath

### DIFF
--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -140,7 +140,7 @@ executable(
 	dependencies: [glib_dep, gtk_dep, gee_dep, m_dep, mutter_dep],
 	vala_args: vala_flags,
 	c_args: compositor_c_args,
-	build_rpath: '-Wl,-rpath,@0@'.format(mutter_typelib_dir),
+	build_rpath: mutter_typelib_dir,
 	install_rpath: mutter_typelib_dir,
 	install: true,
 )


### PR DESCRIPTION
build_rpath should contain just paths, not linker flags:

https://github.com/mesonbuild/meson/blob/0.42.1/docs/markdown/Release-notes-for-0.42.0.md#added-build_rpath-keyword-argument

------

Downstream issue: https://github.com/mesonbuild/meson/blob/0.42.1/docs/markdown/Release-notes-for-0.42.0.md#added-build_rpath-keyword-argument

-------

In the future, the rpath arguments should be replaced with `libdir` of concrete dependencies, or even removed (for meson ≥ 0.47): https://github.com/elementary/gala/pull/200#issuecomment-405113868