### PR TITLE
src/SettingsDaemon: add conditional compilation to account for ubuntu patches

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,13 @@ project(
 gnome = import('gnome')
 i18n = import('i18n')
 
+ubuntu_patched_gsd = get_option('ubuntu-patched-gsd')
+
 add_project_arguments(['--vapidir', join_paths(meson.current_source_dir(), 'vapi')], language: 'vala')
+
+if ubuntu_patched_gsd
+    add_project_arguments(['--define', 'UBUNTU_PATCHED_GSD'], language: 'vala')
+endif
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language:'c')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('ubuntu-patched-gsd', type: 'boolean', value: true) 

--- a/src/SettingsDaemon.vala
+++ b/src/SettingsDaemon.vala
@@ -22,6 +22,7 @@ public class SettingsDaemon : Object {
     private int n_names = 0;
 
     public void start () {
+#if UBUNTU_PATCHED_GSD
         string[] disabled = { "org.gnome.settings-daemon.plugins.background",
                               "org.gnome.settings-daemon.plugins.clipboard",
                               "org.gnome.settings-daemon.plugins.font",
@@ -52,7 +53,7 @@ public class SettingsDaemon : Object {
         foreach (var schema in enabled) {
             set_plugin_enabled (schema, true);
         }
-
+#endif
         /* Pretend to be GNOME session */
         session_manager = new SessionManagerInterface ();
         n_names++;
@@ -71,6 +72,7 @@ public class SettingsDaemon : Object {
                            () => debug ("Failed to acquire name org.gnome.SessionManager"));
     }
 
+#if UBUNTU_PATCHED_GSD
     private void set_plugin_enabled (string schema_name, bool enabled) {
         var source = SettingsSchemaSource.get_default ();
         var schema = source.lookup (schema_name, false);
@@ -79,6 +81,7 @@ public class SettingsDaemon : Object {
             settings.set_boolean ("active", enabled);
         }
     }
+#endif
 
     private void start_settings_daemon () {
         n_names--;

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,13 @@
 conf_data = configuration_data()
 conf_data.set('CONF_DIR', join_paths(get_option('sysconfdir'), 'lightdm'))
 conf_data.set('GETTEXT_PACKAGE', meson.project_name())
-conf_data.set('GSD_DIR', '/usr/lib/gnome-settings-daemon/')
+
+if ubuntu_patched_gsd
+    conf_data.set('GSD_DIR', '/usr/lib/gnome-settings-daemon/')
+else
+    conf_data.set('GSD_DIR', join_paths(get_option('prefix'), get_option('libexecdir')))
+endif
+
 conf_data.set('VERSION', meson.project_version())
 config_header = configure_file (
     input: 'config.vala.in',


### PR DESCRIPTION
This pull request is a straight-forward transformation of my fedora downstream patch into a conditional compilation patch that should be acceptable for merging upstream.

I intended to preserve the current behavior - so, the produced code should not change at all for you. But I don't have to carry a downstream patch anymore and can just flip the conditional compilation with a meson build flag.

It introduces a flag similar to the `ubuntu-bionic-patched-vte` flag already used for terminal.

Fixes #179