### PR TITLE
UserCard: Adjust margins around usernames and avatars

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -45,7 +45,6 @@ public int main (string[] args) {
     var settings_daemon = new Greeter.SettingsDaemon ();
     settings_daemon.start ();
 
-
     Greeter.SubprocessSupervisor compositor;
     Greeter.SubprocessSupervisor wingpanel;
     try {

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -21,7 +21,7 @@ public class Greeter.UserCard : Gtk.Revealer {
         events |= Gdk.EventMask.BUTTON_RELEASE_MASK;
 
         var username_label = new Gtk.Label (lightdm_user.display_name);
-        username_label.margin = 12;
+        username_label.margin = 24;
         username_label.hexpand = true;
         username_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
@@ -53,7 +53,7 @@ public class Greeter.UserCard : Gtk.Revealer {
         var form_grid = new Gtk.Grid ();
         form_grid.column_spacing = 6;
         form_grid.row_spacing = 12;
-        form_grid.margin = 12;
+        form_grid.margin = 24;
         form_grid.margin_top = 0;
         form_grid.attach (login_stack, 0, 1, 1, 1);
         form_grid.attach (session_button, 1, 1, 1, 1);
@@ -91,7 +91,7 @@ public class Greeter.UserCard : Gtk.Revealer {
         }
 
         avatar.valign = Gtk.Align.START;
-        avatar.margin_top = 93;
+        avatar.margin_top = 100;
 
         var card_overlay = new Gtk.Overlay ();
         card_overlay.margin = 12;

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -65,7 +65,6 @@ public class Greeter.UserCard : Gtk.Revealer {
         form_revealer.add (form_grid);
 
         var background_image = new Greeter.BackgroundImage (lightdm_user.background);
-
         bind_property ("show-input", form_revealer, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
 
         var main_grid = new Gtk.Grid ();

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -21,8 +21,7 @@ public class Greeter.UserCard : Gtk.Revealer {
         events |= Gdk.EventMask.BUTTON_RELEASE_MASK;
 
         var username_label = new Gtk.Label (lightdm_user.display_name);
-        username_label.margin_bottom = 12;
-        username_label.margin_top = 24;
+        username_label.margin = 12;
         username_label.hexpand = true;
         username_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
@@ -92,7 +91,7 @@ public class Greeter.UserCard : Gtk.Revealer {
         }
 
         avatar.valign = Gtk.Align.START;
-        avatar.margin_top = 108;
+        avatar.margin_top = 96;
 
         var card_overlay = new Gtk.Overlay ();
         card_overlay.margin = 12;

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -91,7 +91,7 @@ public class Greeter.UserCard : Gtk.Revealer {
         }
 
         avatar.valign = Gtk.Align.START;
-        avatar.margin_top = 96;
+        avatar.margin_top = 93;
 
         var card_overlay = new Gtk.Overlay ();
         card_overlay.margin = 12;


### PR DESCRIPTION
This puts even spacing around the username, which is especially noticeable in collapsed cards. It also ensures that long usernames don't run into the edges of the card

![screenshot from 2018-11-12 13 57 01 2x](https://user-images.githubusercontent.com/7277719/48377506-dcd6c600-e682-11e8-8a5d-0b5535a8746d.png)
