### PR TITLE
Update it.po

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -120,8 +120,8 @@ msgstr "%k:%M"
 #. / AM/PM display, see http://valadoc.org/#!api=glib-2.0/GLib.DateTime.format for more details. If you translate in a language that has no equivalent for AM/PM, keep the original english string.
 #: src/Widgets/TimeLabel.vala:57
 #, c-format
-msgid " %p"
-msgstr " %p"
+msgid ""
+msgstr ""
 
 #~ msgid "Login"
 #~ msgstr "Accesso"


### PR DESCRIPTION
Removed " %p" from AM/PM showing since it's not used in Italian. It is used always either as a 24h format (23.50) or 12h format but without AM/PM (11.50).