### PR TITLE
Create subprocesses after init Gtk and show window.

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -29,6 +29,10 @@ public int main (string[] args) {
     var settings_daemon = new Greeter.SettingsDaemon ();
     settings_daemon.start ();
 
+    Gtk.init (ref args);
+    var window = new Greeter.MainWindow ();
+    window.show_all ();
+
     Greeter.SubprocessSupervisor compositor;
     Greeter.SubprocessSupervisor wingpanel;
     try {
@@ -43,9 +47,6 @@ public int main (string[] args) {
         critical (e.message);
     }
 
-    Gtk.init (ref args);
-    var window = new Greeter.MainWindow ();
-    window.show_all ();
     Gtk.main ();
 
     return 0;


### PR DESCRIPTION
Maybe fixes #178 (unclear whether that issue is due to slow appearance of wingpanel).

With this fix I find that the wingpanel appears almost immediately rather than 20 - 30 seconds after showing the login screen.