### PR TITLE
Re-grab focus after dpi changed

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -239,6 +239,16 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
             return false;
         });
 
+        // regrab focus when dpi changed
+        get_screen ().monitors_changed.connect(() => {
+            present ();
+
+            /* Ensure current card is focused if set */
+            if (current_card != null) {
+                current_card.grab_focus ();
+            }
+        });
+
         destroy.connect (() => {
             Gtk.main_quit ();
         });


### PR DESCRIPTION
I've noticed this resize jump #245 and long thought that might be a cause of losing focus: #144. 
This uses the same principle as #243 to re-grab focus after the dpi changed.
This seems to consistently fix it for me.