### PR TITLE
Fix keyboard focus and wingpanel in greeter

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,7 +31,6 @@ public int main (string[] args) {
 
     Gtk.init (ref args);
 
-
     Greeter.SubprocessSupervisor compositor;
     Greeter.SubprocessSupervisor wingpanel;
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -30,16 +30,19 @@ public int main (string[] args) {
     settings_daemon.start ();
 
     Gtk.init (ref args);
-    var window = new Greeter.MainWindow ();
-    window.show_all ();
+
 
     Greeter.SubprocessSupervisor compositor;
     Greeter.SubprocessSupervisor wingpanel;
+
     try {
         compositor = new Greeter.SubprocessSupervisor ({"io.elementary.greeter-compositor"});
     } catch (Error e) {
         critical (e.message);
     }
+
+    var window = new Greeter.MainWindow ();
+    window.show_all ();
 
     try {
         wingpanel = new Greeter.SubprocessSupervisor ({"wingpanel", "-g"});

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -191,11 +191,6 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
             }
         });
 
-
-        load_users.begin ();
-
-        maximize_window ();
-
         notify["scale-factor"].connect (() => {
             maximize_window ();
         });
@@ -242,6 +237,17 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         destroy.connect (() => {
             Gtk.main_quit ();
         });
+
+        maximize_window ();
+
+        load_users.begin (() => {
+            present ();
+
+            /* Ensure current card is focused if set */
+            if (current_card != null) {
+                current_card.grab_focus ();
+            }
+        });
     }
 
     private void maximize_window () {
@@ -285,19 +291,19 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
 
         critical ("message: `%s' (%d): %s", text, type, messagetext.to_string ());
         /*var messagetext = string_to_messagetext(text);
-        
+
         if (messagetext == MessageText.FPRINT_SWIPE || messagetext == MessageText.FPRINT_PLACE) {
             // For the fprint module, there is no prompt message from PAM.
             send_prompt (PromptType.FPRINT);
-        }  
-        
+        }
+
         current_login.show_message (type, messagetext, text);*/
     }
 
     private void show_prompt (string text, LightDM.PromptType type = LightDM.PromptType.QUESTION) {
         critical ("prompt: `%s' (%d)", text, type);
         /*send_prompt (lightdm_prompttype_to_prompttype(type), string_to_prompttext(text), text);
-        
+
         had_prompt = true;
 
         current_login.show_prompt (type, prompttext, text);*/

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -236,28 +236,32 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
 
         // regrab focus when dpi changed
         get_screen ().monitors_changed.connect(() => {
-            present ();
-
-            /* Ensure current card is focused if set */
-            if (current_card != null) {
-                current_card.grab_focus ();
-            }
+            maximize_and_focus ();
         });
 
         destroy.connect (() => {
             Gtk.main_quit ();
         });
 
-        maximize_window ();
-
         load_users.begin (() => {
-            present ();
-
-            /* Ensure current card is focused if set */
-            if (current_card != null) {
-                current_card.grab_focus ();
-            }
+            /* A significant delay is required in order for the window and card to be focused at
+             * at boot.  TODO: Find whether boot sequence can be tweaked to fix this.
+             */
+            Timeout.add (500, () => {
+                maximize_and_focus ();
+                return Source.REMOVE;
+            });
         });
+
+        maximize_window ();
+    }
+
+    private void maximize_and_focus () {
+        present ();
+        maximize_window ();
+        if (current_card != null) {
+            current_card.grab_focus ();
+        }
     }
 
     private void maximize_window () {
@@ -456,6 +460,8 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         distance = (next_delta - index_delta) * natural_width;
         user_card.notify["reveal-ratio"].connect (notify_cb);
         user_card.show_input = true;
+        user_card.grab_focus ();
+
         if (index_delta != next_delta) {
             ((Greeter.UserCard) user_cards.peek_nth (index_delta)).show_input = false;
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -460,8 +460,6 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         distance = (next_delta - index_delta) * natural_width;
         user_card.notify["reveal-ratio"].connect (notify_cb);
         user_card.show_input = true;
-        user_card.grab_focus ();
-
         if (index_delta != next_delta) {
             ((Greeter.UserCard) user_cards.peek_nth (index_delta)).show_input = false;
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -60,6 +60,9 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
 
         try {
             var settings = Gtk.Settings.get_default ();
+            settings.gtk_icon_theme_name = "elementary";
+            settings.gtk_theme_name = "elementary";
+
             var css_provider = Gtk.CssProvider.get_named (settings.gtk_theme_name, "dark");
             guest_login_button.get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             manual_login_button.get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);


### PR DESCRIPTION
Fixes #144 
Fixes #178 

Although this PR fixes the linked issues (on my system), it is essentially a hack using a timeout to ensure that the current card is the last thing to grab focus, so should be considered temporary or a last resort. A comparatively long delay has been used to try to ensure it is long enough for most systems.

These problem seems to be linked to both the sequence of events at boot (and their relative speed) as well as the sequence of events on starting this application.

In particular there is a longer delay when booting before something happens to steal the focus from the main window compared to when logging in after suspending or logging out.  So the problem might be improved by tweaking the boot sequence.  Note that this focus stealing happens even if the wingpanel is disabled (i.e. that subprocess is never started).