### PR TITLE
Add option to declare path to gnome-settings-daemon

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
-option('ubuntu-patched-gsd', type: 'boolean', value: true) 
+option('ubuntu-patched-gsd', type: 'boolean', value: true)
+option('gsd-dir', type: 'string', value: '')

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,12 +10,19 @@ conf_data = configuration_data()
 conf_data.set('CONF_DIR', join_paths(get_option('sysconfdir'), 'lightdm'))
 conf_data.set('GETTEXT_PACKAGE', meson.project_name())
 
-if ubuntu_patched_gsd
-    conf_data.set('GSD_DIR', '/usr/lib/gnome-settings-daemon/')
-else
-    conf_data.set('GSD_DIR', join_paths(get_option('prefix'), get_option('libexecdir') + '/'))
+gsd_dir = get_option('gsd-dir')
+
+if gsd_dir == ''
+    if ubuntu_patched_gsd
+        gsd_dir = join_paths(get_option('prefix'), get_option('libdir') + '/' + 'gnome-settings-daemon' + '/')
+    else
+        gsd_dir = join_paths(get_option('prefix'), get_option('libexecdir') + '/')
+    endif
 endif
 
+message('Path to gnome-settings-daemon: ' + gsd_dir)
+
+conf_data.set('GSD_DIR', gsd_dir)
 conf_data.set('VERSION', meson.project_version())
 config_header = configure_file (
     input: 'config.vala.in',


### PR DESCRIPTION
#### Motivation for change
In NixOS everything is installed into its own immutable prefix under `/nix/store/*`.

So doing
```
join_paths(get_option('prefix'), get_option('libexecdir') + '/')
```
will never be the `gnome-settings-daemon` prefix.

We also are able to use a `ubuntu-patched-gsd`, so the path problematically turns out to be
```
/usr/lib/gnome-settings-daemon/
```

This patch adds an option `gsd-dir` which will allows us to provide the path to the settings daemon.
Prior to this change we had to build with a patch that would hardcode that path to its proper location.
