### PR TITLE
Fade greeter in to avoid jank

### DIFF
--- a/data/MainWindow.css
+++ b/data/MainWindow.css
@@ -1,0 +1,9 @@
+.background {
+    opacity: 0;
+    transition: opacity 1s ease;
+}
+
+.background.initialized {
+    opacity: 1;
+}
+

--- a/data/greeter.gresource.xml
+++ b/data/greeter.gresource.xml
@@ -3,6 +3,7 @@
   <gresource prefix="/io/elementary/greeter">
     <file alias="Card.css" compressed="true">Card.css</file>
     <file alias="DateTime.css" compressed="true">DateTime.css</file>
+    <file alias="MainWindow.css" compressed="true">MainWindow.css</file>
   </gresource>
   <gresource prefix="/io/elementary/greeter/icons">
     <file alias="/symbolic/fingerprint.svg" compressed="true">fingerprint.svg</file>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -41,6 +41,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
     construct {
         app_paintable = true;
         decorated = false;
+        opacity = 0;
         type_hint = Gdk.WindowTypeHint.DESKTOP;
 
         settings = new Greeter.Settings ();
@@ -259,9 +260,22 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
     private void maximize_and_focus () {
         present ();
         maximize_window ();
+        fade_in ();
         if (current_card != null) {
             current_card.grab_focus ();
         }
+    }
+
+    private void fade_in (double? current_opacity = 0) {
+        Timeout.add (1, () => {
+            if (current_opacity < 1) {
+                opacity = current_opacity;
+                current_opacity += 0.02;
+                fade_in (current_opacity);
+                critical ("Opacity: %lf", current_opacity);
+            }
+            return Source.REMOVE;
+        });
     }
 
     private void maximize_window () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -272,7 +272,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
                 opacity = current_opacity;
                 current_opacity += 0.02;
                 fade_in (current_opacity);
-                critical ("Opacity: %lf", current_opacity);
+                debug ("Opacity: %lf", current_opacity);
             }
             return Source.REMOVE;
         });

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -266,15 +266,15 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         }
     }
 
-    private void fade_in (double? current_opacity = 0) {
-        Timeout.add (1, () => {
-            if (current_opacity < 1) {
-                opacity = current_opacity;
-                current_opacity += 0.02;
-                fade_in (current_opacity);
-                debug ("Opacity: %lf", current_opacity);
-            }
-            return Source.REMOVE;
+    private void fade_in () {
+        double current_opacity = 0;
+
+        Timeout.add (8, () => {
+            opacity = current_opacity;
+            current_opacity += 0.05;
+            debug ("Opacity: %lf", current_opacity);
+
+            return current_opacity < 1;
         });
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -20,6 +20,8 @@
  */
 
 public class Greeter.MainWindow : Gtk.ApplicationWindow {
+    protected static Gtk.CssProvider css_provider;
+
     private GLib.Queue<unowned Greeter.UserCard> user_cards;
     private Gtk.SizeGroup card_size_group;
     private int index_delta = 0;
@@ -38,11 +40,16 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         Gdk.Key.Tab
     };
 
+    static construct {
+        css_provider = new Gtk.CssProvider ();
+        css_provider.load_from_resource ("/io/elementary/greeter/MainWindow.css");
+    }
+
     construct {
         app_paintable = true;
         decorated = false;
-        opacity = 0;
         type_hint = Gdk.WindowTypeHint.DESKTOP;
+        get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         settings = new Greeter.Settings ();
         create_session_selection_action ();
@@ -260,22 +267,11 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
     private void maximize_and_focus () {
         present ();
         maximize_window ();
-        fade_in ();
+        get_style_context ().add_class ("initialized");
+
         if (current_card != null) {
             current_card.grab_focus ();
         }
-    }
-
-    private void fade_in () {
-        double current_opacity = 0;
-
-        Timeout.add (8, () => {
-            opacity = current_opacity;
-            current_opacity += 0.05;
-            debug ("Opacity: %lf", current_opacity);
-
-            return current_opacity < 1;
-        });
     }
 
     private void maximize_window () {


### PR DESCRIPTION
This waits until we do the maximize-and-focus to also fade the greeter in, avoiding any rendering weirdness that happens earlier (like seeing it scaled to 1x on a 2x display).

I have two issues with this:

- [ ] It works fine when running in-session, but seemingly animates twice in the greeter session.
- [ ] It feels weird to be manually animating… would it be better to use a CSS class for this?