### PR TITLE
Save last user on attempted login

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -379,6 +379,10 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
 
     // Called after the credentials are checked, might be authenticated or not.
     private void authentication_complete () {
+        if (current_card is Greeter.UserCard) {
+             settings.last_user = ((Greeter.UserCard)current_card).lightdm_user.name;
+        }
+
         if (lightdm_greeter.is_authenticated) {
             var action_group = get_action_group ("session");
             try {
@@ -509,12 +513,6 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         });
 
         user_card.do_connect.connect (do_connect);
-
-        user_card.notify["child-revealed"].connect (() => {
-            if (user_card.child_revealed) {
-                settings.last_user = user_card.lightdm_user.name;
-            }
-        });
 
         card_size_group.add_widget (user_card);
         user_cards.push_tail (user_card);


### PR DESCRIPTION
Fixes #204 

I'm not sure what the intention was with saving the last user on the revealed signal of a card, and I'm also not sure why it wasn't working.

But surely it's enough to remember the last user that had a successful or unsuccessful login attempt?