### PR TITLE
Clear password entry on error

### DIFF
--- a/src/Cards/ManualCard.vala
+++ b/src/Cards/ManualCard.vala
@@ -78,7 +78,6 @@ public class Greeter.ManualCard : Greeter.BaseCard {
     private void on_login () {
         connecting = true;
         do_connect (password_entry.text);
-        password_entry.text = "";
         password_entry.sensitive = false;
     }
 
@@ -100,6 +99,7 @@ public class Greeter.ManualCard : Greeter.BaseCard {
 
     public override void wrong_credentials () {
         focus_username_entry ();
+        password_entry.text = "";
         weak Gtk.StyleContext grid_style_context = main_grid.get_style_context ();
         weak Gtk.StyleContext username_entry_style_context = username_entry.get_style_context ();
         weak Gtk.StyleContext password_entry_style_context = password_entry.get_style_context ();

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -287,7 +287,8 @@ public class Greeter.UserCard : Greeter.BaseCard {
     }
 
     public override void wrong_credentials () {
-        password_entry.text = "";
+        password_entry.grab_focus ();
+
         weak Gtk.StyleContext entry_style_context = password_entry.get_style_context ();
         entry_style_context.add_class (Gtk.STYLE_CLASS_ERROR);
         main_grid_style_context.add_class ("shake");
@@ -296,6 +297,5 @@ public class Greeter.UserCard : Greeter.BaseCard {
             entry_style_context.remove_class (Gtk.STYLE_CLASS_ERROR);
             return GLib.Source.REMOVE;
         });
-        password_entry.grab_focus_without_selecting ();
     }
 }

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -272,8 +272,6 @@ public class Greeter.UserCard : Greeter.BaseCard {
         } else {
             do_connect ();
         }
-
-        password_entry.text = "";
     }
 
     private void update_collapsed_class () {
@@ -289,6 +287,7 @@ public class Greeter.UserCard : Greeter.BaseCard {
     }
 
     public override void wrong_credentials () {
+        password_entry.text = "";
         weak Gtk.StyleContext entry_style_context = password_entry.get_style_context ();
         entry_style_context.add_class (Gtk.STYLE_CLASS_ERROR);
         main_grid_style_context.add_class ("shake");


### PR DESCRIPTION
For a couple of times now, when I entered my password without really looking at my screen and pressing enter, for a split second I thought that Greeter was never in focus and that I didn't type anything. This was because the password was deleted on the `on_login ()` function. 

This PR just moves the clear password line from `on_login()` to `wrong_credentials()`, that way also when a user types the wrong password, the asterisks will stay in until the User Card starts shaking