### PR TITLE
deb-packaging: remove workaround for Ubuntu patched GSD

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,3 +6,7 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 
 %:
 	dh $@ --buildsystem=meson
+
+override_dh_auto_configure:
+    dh_auto_configure -- \
+		-Dubuntu-patched-gsd=false


### PR DESCRIPTION
Seems Ubuntu don't patch GSD as heavily anymore, so we can remove these workarounds. Will be able to remove the conditional compiles from the code in future I guess, but for now this keeps support for `bionic` too.