### PR TITLE
DBusAccelerator: Fix grab_accelerator argument with Mutter >= 3.22

### DIFF
--- a/compositor/DBusAccelerator.vala
+++ b/compositor/DBusAccelerator.vala
@@ -44,10 +44,10 @@ namespace GreeterCompositor {
 
     public struct Accelerator {
         public string name;
+        public ActionMode flags;
 #if HAS_MUTTER332
         public Meta.KeyBindingFlags grab_flags;
 #endif
-        public ActionMode flags;
     }
 
     [Compact]
@@ -116,7 +116,7 @@ namespace GreeterCompositor {
             }
 
 #if HAS_MUTTER332
-            uint action = wm.get_display ().grab_accelerator (accelerator.name, accelerator.flags);
+            uint action = wm.get_display ().grab_accelerator (accelerator.name, accelerator.grab_flags);
 #elif HAS_MUTTER330
             uint action = wm.get_display ().grab_accelerator (accelerator.name);
 #else


### PR DESCRIPTION
Tiny regression from https://github.com/elementary/greeter/commit/39cba2b462897dbbc10a994e9a8c7c39c4a95178