### PR TITLE
SettingsDaemon: lookup schemas recursive

### DIFF
--- a/src/SettingsDaemon.vala
+++ b/src/SettingsDaemon.vala
@@ -80,7 +80,7 @@ public class Greeter.SettingsDaemon : Object {
 #if UBUNTU_PATCHED_GSD
     private void set_plugin_enabled (string schema_name, bool enabled) {
         var source = SettingsSchemaSource.get_default ();
-        var schema = source.lookup (schema_name, false);
+        var schema = source.lookup (schema_name, true);
         if (schema != null) {
             var settings = new GLib.Settings (schema_name);
             settings.set_boolean ("active", enabled);


### PR DESCRIPTION
The docs on  SettingsSchemaSource get_default say
```
The returned source may actually consist of multiple schema sources from different directories, depending on which directories were given in `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR`. For this reason, all lookups performed against the default source should probably be done recursively.
```

Without this in NixOS it will not work as intended, as we
have multiple entries in XDG_DATA_DIRS.
(we also happen to use an ubuntu patched gsd for pantheon)