### PR TITLE
rules: Specify libexec directory

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,4 +9,5 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-		 -Dubuntu-patched-gsd=false
+		--libexecdir=/usr/libexec \
+		-Dubuntu-patched-gsd=false


### PR DESCRIPTION
dh-compat 10 defaults to /usr/lib/ARCH/ when we want /usr/libexec (also covered by dh-compat 12)

Fixes #427