### PR TITLE
Remove mlockall

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -20,8 +20,6 @@
  */
 
 public int main (string[] args) {
-    Posix.mlockall (Posix.MCL_CURRENT | Posix.MCL_FUTURE);
-
     Intl.setlocale (LocaleCategory.ALL, "");
     Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
     Intl.textdomain (Constants.GETTEXT_PACKAGE);


### PR DESCRIPTION
This seemingly causes the greeter to fail to start on architectures other than amd64 and has been removed from all of the other greeters due to it causing sporadic issues with various versions of systemd.

Apparently it doesn't really offer much extra security (which I think was the original point of using it). Discussion and details here:
https://github.com/canonical/lightdm/issues/55#issuecomment-455559561