### PR TITLE
control: add runtime dep on lightdm

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Homepage: https://github.com/elementary/greeter
 
 Package: pantheon-greeter
 Architecture: any
-Depends: numlockx, ${misc:Depends}, ${shlibs:Depends}
+Depends: numlockx, lightdm, ${misc:Depends}, ${shlibs:Depends}
 Recommends: elementary-default-settings (>= 5.2)
 Provides: lightdm-greeter
 Description: Pantheon Login Screen


### PR DESCRIPTION
I think this is why our daily isos aren't working. Nothing depends on lightdm anymore so it's getting stripped out at the autoremove stages at the end of the install. 