### PR TITLE
Delete io.elementary.greeter.whitelist

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,1 @@
 debian/40-io.elementary.greeter.conf /usr/share/lightdm/lightdm.conf.d/
-debian/io.elementary.greeter.whitelist /etc/wingpanel.d/

--- a/debian/io.elementary.greeter.whitelist
+++ b/debian/io.elementary.greeter.whitelist
@@ -1,6 +1,0 @@
-liba11y.so
-libbluetooth.so
-libkeyboard.so
-libnetwork.so
-libpower.so
-libsession.so


### PR DESCRIPTION
Fixes #449 

This should probably not be needed anymore since indicators know whether they're running in session or not and adapt accordingly