### PR TITLE
Get keyboard layouts from AccountsService

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -529,6 +529,8 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
             binding.unbind ();
         }
 
+        user_card.set_keyboard_layouts ();
+
         binding = user_card.bind_property ("is-24h", datetime_widget, "is-24h", GLib.BindingFlags.SYNC_CREATE);
         next_delta = user_cards.index (user_card);
         int minimum_width, natural_width;

--- a/src/PantheonAccountsServicePlugin.vala
+++ b/src/PantheonAccountsServicePlugin.vala
@@ -10,3 +10,14 @@ interface Pantheon.AccountsService : Object {
     public abstract int sleep_inactive_battery_timeout { get; set; }
     public abstract int sleep_inactive_battery_type { get; set; }
 }
+
+[DBus (name = "io.elementary.SettingsDaemon.AccountsService")]
+interface Pantheon.SettingsDaemon.AccountsService : Object {
+    public struct KeyboardLayout {
+        public string backend;
+        public string name;
+    }
+
+    public abstract KeyboardLayout[] keyboard_layouts { owned get; set; }
+    public abstract uint active_keyboard_layout { get; set; }
+}


### PR DESCRIPTION
If used in conjunction with https://github.com/elementary/settings-daemon , the list of enabled keyboard layouts and the currently active keyboard layout is synchronized between the user's session and the greeter.

When switching cards in the greeter, the list of layouts and active layout is updated on the fly to reflect the user's preferences.

Currently, the wingpanel keyboard indicator works as it does in the session, i.e. if a user has >1 layouts, it will show and allow switching between them. If they only have 1 layout, it will not be visible while that user's card is selected. But their layout will be active.