### PR TITLE
Fix compiler warnings

### DIFF
--- a/compositor/DBusAccelerator.vala
+++ b/compositor/DBusAccelerator.vala
@@ -160,7 +160,7 @@ namespace GreeterCompositor {
         }
 
 #if HAS_MUTTER334
-        public bool ungrab_accelerators (uint[] actions) throws DBusError, IOError {
+        public bool ungrab_accelerators (uint[] actions) throws GLib.Error {
             foreach (uint action in actions) {
                 ungrab_accelerator (action);
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -307,13 +307,13 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void maximize_window () {
-        int x, y;
         var display = Gdk.Display.get_default ();
         unowned Gdk.Seat seat = display.get_default_seat ();
         unowned Gdk.Device? pointer = seat.get_pointer ();
 
         Gdk.Monitor? monitor;
         if (pointer != null) {
+            int x, y;
             pointer.get_position (null, out x, out y);
             monitor = display.get_monitor_at_point (x, y);
         } else {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -309,8 +309,17 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
     private void maximize_window () {
         int x, y;
         var display = Gdk.Display.get_default ();
-        display.get_pointer (null, out x, out y, null);
-        var monitor = display.get_monitor_at_point (x, y);
+        unowned Gdk.Seat seat = display.get_default_seat ();
+        unowned Gdk.Device? pointer = seat.get_pointer ();
+
+        Gdk.Monitor? monitor;
+        if (pointer != null) {
+            pointer.get_position (null, out x, out y);
+            monitor = display.get_monitor_at_point (x, y);
+        } else {
+            monitor = display.get_primary_monitor ();
+        }
+
         var rect = monitor.get_geometry ();
         resize (rect.width, rect.height);
         move (rect.x, rect.y);


### PR DESCRIPTION
`Display.get_pointer` is deprecated, so we replace this with getting the pointer device from the seat. There's a fallback to use the primary monitor here if we can't detect which monitor the mouse is on for some reason. But, I've tested this with multiple monitors and the login dialog still moves onto the monitor the pointer is on.

