### PR TITLE
Set XDG_CURRENT_DESKTOP to Pantheon

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,6 +23,10 @@ public int main (string[] args) {
     Intl.setlocale (LocaleCategory.ALL, "");
     Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
     Intl.textdomain (Constants.GETTEXT_PACKAGE);
+    
+    // Ensure we present ourselves as Pantheon so we pick up the right GSettings
+    // overrides
+    GLib.Environment.set_variable ("XDG_CURRENT_DESKTOP", "Pantheon", true);
 
     var settings_daemon = new Greeter.SettingsDaemon ();
     settings_daemon.start ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,7 +23,7 @@ public int main (string[] args) {
     Intl.setlocale (LocaleCategory.ALL, "");
     Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
     Intl.textdomain (Constants.GETTEXT_PACKAGE);
-    
+
     // Ensure we present ourselves as Pantheon so we pick up the right GSettings
     // overrides
     GLib.Environment.set_variable ("XDG_CURRENT_DESKTOP", "Pantheon", true);


### PR DESCRIPTION
To be used in conjunction with https://github.com/elementary/default-settings/pull/186/ so that we adopt the GSettings overrides, even in the case where they're specific to Pantheon.