### PR TITLE
meson: remove ubuntu-patched-gsd option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,13 +8,8 @@ project(
 gnome = import('gnome')
 i18n = import('i18n')
 
-ubuntu_patched_gsd = get_option('ubuntu-patched-gsd')
 
 add_project_arguments(['--vapidir', join_paths(meson.current_source_dir(), 'vapi')], language: 'vala')
-
-if ubuntu_patched_gsd
-    add_project_arguments(['--define', 'UBUNTU_PATCHED_GSD'], language: 'vala')
-endif
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language:'c')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,1 @@
-option('ubuntu-patched-gsd', type: 'boolean', value: true)
 option('gsd-dir', type: 'string', value: '')

--- a/src/SettingsDaemon.vala
+++ b/src/SettingsDaemon.vala
@@ -23,42 +23,6 @@ public class Greeter.SettingsDaemon : Object {
     private SubprocessSupervisor[] supervisors = {};
 
     public void start () {
-#if UBUNTU_PATCHED_GSD
-        string[] disabled = {
-            "org.gnome.settings-daemon.plugins.background",
-            "org.gnome.settings-daemon.plugins.clipboard",
-            "org.gnome.settings-daemon.plugins.font",
-            "org.gnome.settings-daemon.plugins.gconf",
-            "org.gnome.settings-daemon.plugins.gsdwacom",
-            "org.gnome.settings-daemon.plugins.housekeeping",
-            "org.gnome.settings-daemon.plugins.keybindings",
-            "org.gnome.settings-daemon.plugins.keyboard",
-            "org.gnome.settings-daemon.plugins.mouse",
-            "org.gnome.settings-daemon.plugins.print-notifications",
-            "org.gnome.settings-daemon.plugins.smartcard",
-            "org.gnome.settings-daemon.plugins.wacom"
-        };
-
-        string[] enabled = {
-            "org.gnome.settings-daemon.plugins.a11y-keyboard",
-            "org.gnome.settings-daemon.plugins.a11y-settings",
-            "org.gnome.settings-daemon.plugins.color",
-            "org.gnome.settings-daemon.plugins.cursor",
-            "org.gnome.settings-daemon.plugins.media-keys",
-            "org.gnome.settings-daemon.plugins.power",
-            "org.gnome.settings-daemon.plugins.sound",
-            "org.gnome.settings-daemon.plugins.xrandr",
-            "org.gnome.settings-daemon.plugins.xsettings"
-        };
-
-        foreach (var schema in disabled) {
-            set_plugin_enabled (schema, false);
-        }
-
-        foreach (var schema in enabled) {
-            set_plugin_enabled (schema, true);
-        }
-#endif
         /* Pretend to be GNOME session */
         session_manager = new Greeter.GnomeSessionManager ();
         n_names++;
@@ -76,17 +40,6 @@ public class Greeter.SettingsDaemon : Object {
                            },
                            () => debug ("Failed to acquire name org.gnome.SessionManager"));
     }
-
-#if UBUNTU_PATCHED_GSD
-    private void set_plugin_enabled (string schema_name, bool enabled) {
-        var source = SettingsSchemaSource.get_default ();
-        var schema = source.lookup (schema_name, true);
-        if (schema != null) {
-            var settings = new GLib.Settings (schema_name);
-            settings.set_boolean ("active", enabled);
-        }
-    }
-#endif
 
     private void start_settings_daemon () {
         n_names--;

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,11 +15,7 @@ conf_data.set('GETTEXT_PACKAGE', meson.project_name())
 gsd_dir = get_option('gsd-dir')
 
 if gsd_dir == ''
-    if ubuntu_patched_gsd
-        gsd_dir = join_paths(get_option('prefix'), 'lib', 'gnome-settings-daemon' + '/')
-    else
-        gsd_dir = join_paths(get_option('prefix'), get_option('libexecdir') + '/')
-    endif
+    gsd_dir = join_paths(get_option('prefix'), get_option('libexecdir') + '/')
 endif
 
 message('Path to gnome-settings-daemon: ' + gsd_dir)


### PR DESCRIPTION
We build with this option set to false in Odin already which is causing some confusion when people are building the greeter from git for Odin and it's defaulting to true.

https://github.com/elementary/greeter/pull/417

Since the release CI workflow is already pointing to Odin, we can drop this now and any late-life support we do for bionic will be via backports onto the hera branch, so we just don't backport this commit.