### PR TITLE
debian: Remove ubuntu-patched-gsd option

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,3 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		--libexecdir=/usr/libexec \
-		-Dubuntu-patched-gsd=false


### PR DESCRIPTION
To go with #487 