### PR TITLE
KeyboardManager: Ignore input-source type if not "xkb"

### DIFF
--- a/compositor/KeyboardManager.vala
+++ b/compositor/KeyboardManager.vala
@@ -93,6 +93,8 @@ namespace GreeterCompositor {
                 string[] arr = name.split ("+", 2);
                 layout = arr[0];
                 variant = arr[1] ?? "";
+            } else {
+                return;  //We do not want to change the current xkb layout here when using ibus.
             }
 
             var xkb_options = settings.get_strv ("xkb-options");


### PR DESCRIPTION
Analagous to https://github.com/elementary/gala/pull/1041 and required before https://github.com/elementary/switchboard-plug-keyboard/pull/341 (which adds "ibus" input-source type) can be merged.