### PR TITLE
MainWindow: Use scroll and swipe handling from Hdy

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -69,6 +69,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         extra_login_grid.valign = Gtk.Align.END;
         extra_login_grid.column_spacing = 12;
         extra_login_grid.column_homogeneous = true;
+        extra_login_grid.attach (manual_login_button, 1, 0);
 
         try {
             var gtksettings = Gtk.Settings.get_default ();
@@ -91,19 +92,23 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
             allow_long_swipes = true,
             vexpand = true
         };
-        carousel.add (manual_card);
+
+        var manual_login_stack = new Gtk.Stack () {
+            transition_type = Gtk.StackTransitionType.CROSSFADE
+        };
+        manual_login_stack.add (carousel);
+        manual_login_stack.add (manual_card);
 
         var main_grid = new Gtk.Grid ();
         main_grid.margin_top = main_grid.margin_bottom = 24;
         main_grid.row_spacing = 24;
         main_grid.orientation = Gtk.Orientation.VERTICAL;
         main_grid.add (datetime_widget);
-        main_grid.add (carousel);
+        main_grid.add (manual_login_stack);
         main_grid.add (extra_login_grid);
 
         add (main_grid);
 
-        manual_login_button.bind_property ("active", manual_card, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
         manual_login_button.toggled.connect (() => {
             if (manual_login_button.active) {
                 if (lightdm_greeter.in_authentication) {
@@ -114,6 +119,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
                     }
                 }
 
+                manual_login_stack.visible_child = manual_card;
                 current_card = manual_card;
             } else {
                 if (lightdm_greeter.in_authentication) {
@@ -124,6 +130,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
                     }
                 }
 
+                manual_login_stack.visible_child = carousel;
                 current_card = user_cards.peek_nth (index_delta);
                 try {
                     lightdm_greeter.authenticate (((UserCard) current_card).lightdm_user.name);
@@ -494,8 +501,6 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
     private void add_card (LightDM.User lightdm_user) {
         var user_card = new Greeter.UserCard (lightdm_user);
         user_card.show_all ();
-
-        manual_login_button.bind_property ("active", user_card, "reveal-child", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.INVERT_BOOLEAN);
 
         carousel.add (user_card);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -88,7 +88,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         var manual_card = new Greeter.ManualCard ();
 
         carousel = new Hdy.Carousel () {
-            interactive = false,
+            allow_long_swipes = true,
             vexpand = true
         };
         carousel.add (manual_card);
@@ -141,22 +141,22 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
             }
         });
 
-        GLib.ActionEntry entries[] = {
-            GLib.ActionEntry () {
-                name = "previous",
-                activate = go_previous
-            },
-            GLib.ActionEntry () {
-                name = "next",
-                activate = go_next
-            }
-        };
+        // GLib.ActionEntry entries[] = {
+        //     GLib.ActionEntry () {
+        //         name = "previous",
+        //         activate = go_previous
+        //     },
+        //     GLib.ActionEntry () {
+        //         name = "next",
+        //         activate = go_next
+        //     }
+        // };
 
         card_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
         card_size_group.add_widget (extra_login_grid);
         card_size_group.add_widget (manual_card);
 
-        add_action_entries (entries, this);
+        // add_action_entries (entries, this);
 
         lightdm_greeter = new LightDM.Greeter ();
         lightdm_greeter.show_message.connect (show_message);
@@ -192,58 +192,50 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         manual_card.do_connect_username.connect (do_connect_username);
         manual_card.do_connect.connect (do_connect);
 
-        key_press_event.connect ((event) => {
-            // arrow key is being used to navigate
-            if (event.keyval in NAVIGATION_KEYS) {
-                if (current_card is UserCard) {
-                    weak Gtk.Widget? current_focus = get_focus ();
-                    if (current_focus is Gtk.Entry && current_focus.is_ancestor (current_card)) {
-                        if (((Gtk.Entry) current_focus).text == "") {
-                            if (event.keyval == Gdk.Key.Left) {
-                                if (get_style_context ().direction == Gtk.TextDirection.RTL) {
-                                    activate_action ("next", null);
-                                } else {
-                                    activate_action ("previous", null);
-                                }
-                                return true;
-                            } else if (event.keyval == Gdk.Key.Right) {
-                                if (get_style_context ().direction == Gtk.TextDirection.RTL) {
-                                    activate_action ("previous", null);
-                                } else {
-                                    activate_action ("next", null);
-                                }
-                                return true;
-                            }
-                        }
-                    }
-                }
+        // key_press_event.connect ((event) => {
+        //     // arrow key is being used to navigate
+        //     if (event.keyval in NAVIGATION_KEYS) {
+        //         if (current_card is UserCard) {
+        //             weak Gtk.Widget? current_focus = get_focus ();
+        //             if (current_focus is Gtk.Entry && current_focus.is_ancestor (current_card)) {
+        //                 if (((Gtk.Entry) current_focus).text == "") {
+        //                     if (event.keyval == Gdk.Key.Left) {
+        //                         if (get_style_context ().direction == Gtk.TextDirection.RTL) {
+        //                             activate_action ("next", null);
+        //                         } else {
+        //                             activate_action ("previous", null);
+        //                         }
+        //                         return true;
+        //                     } else if (event.keyval == Gdk.Key.Right) {
+        //                         if (get_style_context ().direction == Gtk.TextDirection.RTL) {
+        //                             activate_action ("previous", null);
+        //                         } else {
+        //                             activate_action ("next", null);
+        //                         }
+        //                         return true;
+        //                     }
+        //                 }
+        //             }
+        //         }
 
-                return false;
+        //         return false;
+        //     }
+
+        //     // Don't focus if it is a modifier or if search_box is already focused
+        //     weak Gtk.Widget? current_focus = get_focus ();
+        //     if ((event.is_modifier == 0) && (current_focus == null || !current_focus.is_ancestor (current_card))) {
+        //         current_card.grab_focus ();
+        //     }
+
+        //     return false;
+        // });
+
+        carousel.page_changed.connect ((index) => {
+            var children = carousel.get_children ();
+
+            if (children.nth_data (index) is Greeter.UserCard) {
+                switch_to_card ((Greeter.UserCard) children.nth_data (index));
             }
-
-            // Don't focus if it is a modifier or if search_box is already focused
-            weak Gtk.Widget? current_focus = get_focus ();
-            if ((event.is_modifier == 0) && (current_focus == null || !current_focus.is_ancestor (current_card))) {
-                current_card.grab_focus ();
-            }
-
-            return false;
-        });
-
-        add_events (Gdk.EventMask.SCROLL_MASK);
-
-        scroll_event.connect ((event) => {
-            switch (event.direction) {
-                case Gdk.ScrollDirection.UP:
-                case Gdk.ScrollDirection.LEFT:
-                    activate_action ("previous", null);
-                    break;
-                case Gdk.ScrollDirection.DOWN:
-                case Gdk.ScrollDirection.RIGHT:
-                    activate_action ("next", null);
-                    break;
-            }
-            return false;
         });
 
         // regrab focus when dpi changed
@@ -614,17 +606,17 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         }
     }
 
-    private void go_previous (GLib.SimpleAction action, GLib.Variant? parameter) {
-        unowned Greeter.UserCard? next_card = (Greeter.UserCard) user_cards.peek_nth (index_delta - 1);
-        if (next_card != null) {
-            switch_to_card (next_card);
-        }
-    }
+    // private void go_previous (GLib.SimpleAction action, GLib.Variant? parameter) {
+    //     unowned Greeter.UserCard? next_card = (Greeter.UserCard) user_cards.peek_nth (index_delta - 1);
+    //     if (next_card != null) {
+    //         switch_to_card (next_card);
+    //     }
+    // }
 
-    private void go_next (GLib.SimpleAction action, GLib.Variant? parameter) {
-        unowned Greeter.UserCard? next_card = (Greeter.UserCard) user_cards.peek_nth (index_delta + 1);
-        if (next_card != null) {
-            switch_to_card (next_card);
-        }
-    }
+    // private void go_next (GLib.SimpleAction action, GLib.Variant? parameter) {
+    //     unowned Greeter.UserCard? next_card = (Greeter.UserCard) user_cards.peek_nth (index_delta + 1);
+    //     if (next_card != null) {
+    //         switch_to_card (next_card);
+    //     }
+    // }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -141,22 +141,22 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
             }
         });
 
-        // GLib.ActionEntry entries[] = {
-        //     GLib.ActionEntry () {
-        //         name = "previous",
-        //         activate = go_previous
-        //     },
-        //     GLib.ActionEntry () {
-        //         name = "next",
-        //         activate = go_next
-        //     }
-        // };
+        GLib.ActionEntry entries[] = {
+            GLib.ActionEntry () {
+                name = "previous",
+                activate = go_previous
+            },
+            GLib.ActionEntry () {
+                name = "next",
+                activate = go_next
+            }
+        };
 
         card_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
         card_size_group.add_widget (extra_login_grid);
         card_size_group.add_widget (manual_card);
 
-        // add_action_entries (entries, this);
+        add_action_entries (entries, this);
 
         lightdm_greeter = new LightDM.Greeter ();
         lightdm_greeter.show_message.connect (show_message);
@@ -192,43 +192,43 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         manual_card.do_connect_username.connect (do_connect_username);
         manual_card.do_connect.connect (do_connect);
 
-        // key_press_event.connect ((event) => {
-        //     // arrow key is being used to navigate
-        //     if (event.keyval in NAVIGATION_KEYS) {
-        //         if (current_card is UserCard) {
-        //             weak Gtk.Widget? current_focus = get_focus ();
-        //             if (current_focus is Gtk.Entry && current_focus.is_ancestor (current_card)) {
-        //                 if (((Gtk.Entry) current_focus).text == "") {
-        //                     if (event.keyval == Gdk.Key.Left) {
-        //                         if (get_style_context ().direction == Gtk.TextDirection.RTL) {
-        //                             activate_action ("next", null);
-        //                         } else {
-        //                             activate_action ("previous", null);
-        //                         }
-        //                         return true;
-        //                     } else if (event.keyval == Gdk.Key.Right) {
-        //                         if (get_style_context ().direction == Gtk.TextDirection.RTL) {
-        //                             activate_action ("previous", null);
-        //                         } else {
-        //                             activate_action ("next", null);
-        //                         }
-        //                         return true;
-        //                     }
-        //                 }
-        //             }
-        //         }
+        key_press_event.connect ((event) => {
+            // arrow key is being used to navigate
+            if (event.keyval in NAVIGATION_KEYS) {
+                if (current_card is UserCard) {
+                    weak Gtk.Widget? current_focus = get_focus ();
+                    if (current_focus is Gtk.Entry && current_focus.is_ancestor (current_card)) {
+                        if (((Gtk.Entry) current_focus).text == "") {
+                            if (event.keyval == Gdk.Key.Left) {
+                                if (get_style_context ().direction == Gtk.TextDirection.RTL) {
+                                    activate_action ("next", null);
+                                } else {
+                                    activate_action ("previous", null);
+                                }
+                                return true;
+                            } else if (event.keyval == Gdk.Key.Right) {
+                                if (get_style_context ().direction == Gtk.TextDirection.RTL) {
+                                    activate_action ("previous", null);
+                                } else {
+                                    activate_action ("next", null);
+                                }
+                                return true;
+                            }
+                        }
+                    }
+                }
 
-        //         return false;
-        //     }
+                return false;
+            }
 
-        //     // Don't focus if it is a modifier or if search_box is already focused
-        //     weak Gtk.Widget? current_focus = get_focus ();
-        //     if ((event.is_modifier == 0) && (current_focus == null || !current_focus.is_ancestor (current_card))) {
-        //         current_card.grab_focus ();
-        //     }
+            // Don't focus if it is a modifier or if search_box is already focused
+            weak Gtk.Widget? current_focus = get_focus ();
+            if ((event.is_modifier == 0) && (current_focus == null || !current_focus.is_ancestor (current_card))) {
+                current_card.grab_focus ();
+            }
 
-        //     return false;
-        // });
+            return false;
+        });
 
         carousel.page_changed.connect ((index) => {
             var children = carousel.get_children ();
@@ -606,17 +606,17 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         }
     }
 
-    // private void go_previous (GLib.SimpleAction action, GLib.Variant? parameter) {
-    //     unowned Greeter.UserCard? next_card = (Greeter.UserCard) user_cards.peek_nth (index_delta - 1);
-    //     if (next_card != null) {
-    //         switch_to_card (next_card);
-    //     }
-    // }
+    private void go_previous (GLib.SimpleAction action, GLib.Variant? parameter) {
+        unowned Greeter.UserCard? next_card = (Greeter.UserCard) user_cards.peek_nth (index_delta - 1);
+        if (next_card != null) {
+            carousel.scroll_to (next_card);
+        }
+    }
 
-    // private void go_next (GLib.SimpleAction action, GLib.Variant? parameter) {
-    //     unowned Greeter.UserCard? next_card = (Greeter.UserCard) user_cards.peek_nth (index_delta + 1);
-    //     if (next_card != null) {
-    //         switch_to_card (next_card);
-    //     }
-    // }
+    private void go_next (GLib.SimpleAction action, GLib.Variant? parameter) {
+        unowned Greeter.UserCard? next_card = (Greeter.UserCard) user_cards.peek_nth (index_delta + 1);
+        if (next_card != null) {
+            carousel.scroll_to (next_card);
+        }
+    }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -69,7 +69,6 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         extra_login_grid.valign = Gtk.Align.END;
         extra_login_grid.column_spacing = 12;
         extra_login_grid.column_homogeneous = true;
-        extra_login_grid.attach (manual_login_button, 1, 0);
 
         try {
             var gtksettings = Gtk.Settings.get_default ();


### PR DESCRIPTION
Replaces custom scroll handling with scroll and swipe handling native to Hdy.Carousel. This both gives us 1:1 swiping and long swiping across several cards

The previous method here relied on packing hidden cards into the carousel and hiding and showing all cards for the manual card entry. This doesn't work because you can swipe over to hidden cards, which is bad. So instead, use a Gtk.Stack to switch between manual login and user cards