### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,6 +23,7 @@ public int main (string[] args) {
     Intl.setlocale (LocaleCategory.ALL, "");
     Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
     Intl.textdomain (Constants.GETTEXT_PACKAGE);
+    Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALE_DIR);
 
     // Ensure we present ourselves as Pantheon so we pick up the right GSettings
     // overrides

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -3,4 +3,5 @@ namespace Constants {
     public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
     public const string GSD_DIR = "@GSD_DIR@";
     public const string VERSION = "@VERSION@";
+    public const string LOCALE_DIR = "@LOCALE_DIR@";
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ install_path = join_paths(get_option('prefix'), get_option('sbindir'))
 conf_data = configuration_data()
 conf_data.set('CONF_DIR', join_paths(get_option('sysconfdir'), 'lightdm'))
 conf_data.set('GETTEXT_PACKAGE', meson.project_name())
+conf_data.set('LOCALE_DIR', join_paths(get_option('prefix'), get_option('localedir')))
 
 gsd_dir = get_option('gsd-dir')
 


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)