### PR TITLE
Wait for graphics drivers to be ready before launching Xorg

### DIFF
--- a/debian/40-io.elementary.greeter.conf
+++ b/debian/40-io.elementary.greeter.conf
@@ -1,3 +1,7 @@
+[LightDM]
+# Wait for graphics drivers to be ready before launching Xorg
+logind-check-graphical=true
+
 [Seat:*]
 greeter-session=io.elementary.greeter
 user-session=pantheon


### PR DESCRIPTION
This is the cause of a very confusing bug that I was experiencing with my nvidia card. After installing the proprietary drivers, it was kind of random as to whether they'd work correctly in a given session. The nvidia X settings application would show up blank, and Xorg would be running using the Nouveau driver, even though the proprietary kernel module was loaded.

It turns out that there's a race condition where lightdm can start and launch Xorg before the nvidia kernel module is loaded. Meaning that when Xorg does its autoconfiguration, it loads the Nouveau Xorg driver for the card instead of the proprietary one, leading to all kinds of badness.

This causes lightdm to wait for the graphics devices to be ready before trying to spawn the greeter.

Info found here: https://bbs.archlinux.org/viewtopic.php?id=260293

Confirmed to fix the issue on my machine.