### PR TITLE
control: Allow building against newer mutter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper (>= 10.5.1),
                libgtk-3-dev,
                libhandy-1-dev,
                liblightdm-gobject-1-dev (>= 1.2.1),
-               libmutter-6-dev | libmutter-5-dev | libmutter-4-dev | libmutter-3-dev | libmutter-2-dev,
+               libmutter-8-dev | libmutter-7-dev | libmutter-6-dev | libmutter-5-dev | libmutter-4-dev | libmutter-3-dev | libmutter-2-dev,
                libx11-dev,
                meson,
                valac (>= 0.26)


### PR DESCRIPTION
Allows us to build against newer mutter versions in the daily PPA