### PR TITLE
Meson: remove positional arguments from i18n.merge_file

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,6 @@ desktop_in = configure_file (
 )
 
 i18n.merge_file (
-    'desktop',
     input: desktop_in,
     output: meson.project_name() + '.desktop',
     install: true,


### PR DESCRIPTION
`i18n.merge_file` has been ignoring positional arguments for a time and explicitly rejects with error since meson 0.60.0.