### PR TITLE
Modifying the logged_in variable to be class private to allow access …

### DIFF
--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -42,6 +42,7 @@ public class Greeter.UserCard : Greeter.BaseCard {
     private Gtk.Stack login_stack;
     private Greeter.PasswordEntry password_entry;
 
+    private SelectionCheck logged_in;
     private unowned Gtk.StyleContext logged_in_context;
     private weak Gtk.StyleContext main_grid_style_context;
     private weak Gtk.StyleContext password_entry_context;
@@ -214,7 +215,7 @@ public class Greeter.UserCard : Greeter.BaseCard {
         };
         avatar_overlay.add (avatar);
 
-        var logged_in = new SelectionCheck () {
+        logged_in = new SelectionCheck () {
             halign = Gtk.Align.END,
             valign = Gtk.Align.END
         };


### PR DESCRIPTION
…outside of the function it is allocated in.  The logged_in variable is referenced by a different function, and a race condition can occur, causing a de reference to a freed element.