### PR TITLE
compositor: Add Wingpanel Background interface

### DIFF
--- a/compositor/BackgroundManager.vala
+++ b/compositor/BackgroundManager.vala
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2011-2015 Wingpanel Developers (http://launchpad.net/wingpanel)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+public enum BackgroundState {
+    LIGHT,
+    DARK,
+    MAXIMIZED,
+    TRANSLUCENT_DARK,
+    TRANSLUCENT_LIGHT
+}
+
+public class GreeterCompositor.BackgroundManager : Object {
+    private const int MINIMIZE_DURATION = 200;
+    private const int SNAP_DURATION = 250;
+    private const int WALLPAPER_TRANSITION_DURATION = 150;
+    private const int WORKSPACE_SWITCH_DURATION = 300;
+    private const double ACUTANCE_THRESHOLD = 8;
+    private const double STD_THRESHOLD = 45;
+    private const double LUMINANCE_THRESHOLD = 180;
+
+    public signal void state_changed (BackgroundState state, uint animation_duration);
+
+    public int panel_height { private get; construct; }
+    private static WindowManager wm;
+
+    private Meta.Workspace? current_workspace = null;
+
+    private BackgroundState current_state = BackgroundState.LIGHT;
+
+    private BackgroundUtils.ColorInformation? bk_color_info = null;
+
+    public BackgroundManager (WindowManager _wm, int panel_height) {
+        wm = _wm;
+
+        Object (panel_height: panel_height);
+
+        connect_signals ();
+        update_bk_color_info.begin ((obj, res) => {
+            update_bk_color_info.end (res);
+            update_current_workspace ();
+        });
+    }
+
+    private void connect_signals () {
+        unowned Meta.WorkspaceManager manager = wm.get_display ().get_workspace_manager ();
+        manager.workspace_switched.connect (() => {
+            update_current_workspace ();
+        });
+
+        wm.notify["system-background"].connect (() => {
+            update_bk_color_info.begin ((obj, res) => {
+                update_bk_color_info.end (res);
+                check_for_state_change (WALLPAPER_TRANSITION_DURATION);
+            });
+        });
+    }
+
+    private void update_current_workspace () {
+        unowned Meta.WorkspaceManager manager = wm.get_display ().get_workspace_manager ();
+        var workspace = manager.get_active_workspace ();
+
+        if (workspace == null) {
+            warning ("Cannot get active workspace");
+
+            return;
+        }
+
+        if (current_workspace != null) {
+            current_workspace.window_added.disconnect (on_window_added);
+            current_workspace.window_removed.disconnect (on_window_removed);
+        }
+
+        current_workspace = workspace;
+
+        foreach (Meta.Window window in current_workspace.list_windows ()) {
+            if (window.is_on_primary_monitor ()) {
+                register_window (window);
+            }
+        }
+
+        current_workspace.window_added.connect (on_window_added);
+        current_workspace.window_removed.connect (on_window_removed);
+
+        check_for_state_change (WORKSPACE_SWITCH_DURATION);
+    }
+
+    private void register_window (Meta.Window window) {
+        window.notify["maximized-vertically"].connect (() => {
+            check_for_state_change (SNAP_DURATION);
+        });
+
+        window.notify["minimized"].connect (() => {
+            check_for_state_change (MINIMIZE_DURATION);
+        });
+
+        window.workspace_changed.connect (() => {
+            check_for_state_change (WORKSPACE_SWITCH_DURATION);
+        });
+    }
+
+    private void on_window_added (Meta.Window window) {
+        register_window (window);
+
+        check_for_state_change (SNAP_DURATION);
+    }
+
+    private void on_window_removed (Meta.Window window) {
+        check_for_state_change (SNAP_DURATION);
+    }
+
+    public async void update_bk_color_info () {
+        SourceFunc callback = update_bk_color_info.callback;
+
+        var monitor = wm.get_display ().get_primary_monitor ();
+        var monitor_geometry = wm.get_display ().get_monitor_geometry (monitor);
+
+        BackgroundUtils.get_background_color_information.begin (wm, 0, 0, monitor_geometry.width, panel_height, (obj, res) => {
+            try {
+                bk_color_info = BackgroundUtils.get_background_color_information.end (res);
+            } catch (Error e) {
+                warning (e.message);
+            } finally {
+                callback ();
+            }
+        });
+
+        yield;
+    }
+
+    /**
+     * Check if Wingpanel's background state should change.
+     *
+     * The state is defined as follows:
+     *  - If there's a maximized window, the state should be MAXIMIZED;
+     *  - If no information about the background could be gathered, it should be TRANSLUCENT;
+     *  - If there's too much contrast or sharpness, it should be TRANSLUCENT;
+     *  - If the background is too bright, it should be DARK;
+     *  - Else it should be LIGHT.
+     */
+    private void check_for_state_change (uint animation_duration) {
+        bool has_maximized_window = false;
+
+        foreach (Meta.Window window in current_workspace.list_windows ()) {
+            if (window.is_on_primary_monitor ()) {
+                if (!window.minimized && window.maximized_vertically) {
+                    has_maximized_window = true;
+                    break;
+                }
+            }
+        }
+
+        BackgroundState new_state;
+
+        if (has_maximized_window) {
+            new_state = BackgroundState.MAXIMIZED;
+        } else if (bk_color_info == null) {
+            new_state = BackgroundState.TRANSLUCENT_LIGHT;
+        } else {
+            var luminance_std = Math.sqrt (bk_color_info.luminance_variance);
+
+            bool bg_is_busy = luminance_std > STD_THRESHOLD ||
+                (bk_color_info.mean_luminance < LUMINANCE_THRESHOLD &&
+                bk_color_info.mean_luminance + 1.645 * luminance_std > LUMINANCE_THRESHOLD ) ||
+                bk_color_info.mean_acutance > ACUTANCE_THRESHOLD;
+
+            bool bg_is_dark = bk_color_info.mean_luminance > LUMINANCE_THRESHOLD;
+            bool bg_is_busy_dark = bk_color_info.mean_luminance * 1.25 > LUMINANCE_THRESHOLD;
+
+            if (bg_is_busy && bg_is_busy_dark) {
+                new_state = BackgroundState.TRANSLUCENT_DARK;
+            } else if (bg_is_busy) {
+                new_state = BackgroundState.TRANSLUCENT_LIGHT;
+            } else if (bg_is_dark) {
+                new_state = BackgroundState.DARK;
+            } else {
+                new_state = BackgroundState.LIGHT;
+            }
+        }
+
+        if (new_state != current_state) {
+            state_changed (current_state = new_state, animation_duration);
+        }
+    }
+}

--- a/compositor/BackgroundUtils.vala
+++ b/compositor/BackgroundUtils.vala
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2011-2015 Wingpanel Developers (http://launchpad.net/wingpanel)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+/*
+ *   The method for calculating the background information and the classes that are
+ *   related to it are copied from Gala.DBus.
+ */
+
+ namespace BackgroundUtils {
+    private const double SATURATION_WEIGHT = 1.5;
+    private const double WEIGHT_THRESHOLD = 1.0;
+
+    private class DummyOffscreenEffect : Clutter.OffscreenEffect {
+        public signal void done_painting ();
+#if HAS_MUTTER40
+        public override void post_paint (Clutter.PaintNode node, Clutter.PaintContext context) {
+            base.post_paint (node, context);
+#else
+        public override void post_paint (Clutter.PaintContext context) {
+            base.post_paint (context);
+#endif
+            Idle.add (() => {
+                done_painting ();
+                return false;
+            });
+        }
+    }
+
+    public struct ColorInformation {
+        double average_red;
+        double average_green;
+        double average_blue;
+        double mean_luminance;
+        double luminance_variance;
+        double mean_acutance;
+    }
+
+    public async ColorInformation get_background_color_information (GreeterCompositor.WindowManager wm,
+                                                                    int reference_x, int reference_y, int reference_width, int reference_height) throws DBusError {
+        var background = wm.system_background.background_actor;
+
+        var effect = new DummyOffscreenEffect ();
+        background.add_effect (effect);
+
+        var bg_actor_width = (int)background.width;
+        var bg_actor_height = (int)background.height;
+
+        // A commit in mutter added some padding to offscreen textures, so we
+        // need to avoid looking at the edges of the texture as it often has a
+        // black border. The commit specifies that up to 1.75px around each side
+        // could now be padding, so cut off 2px from left and top if necessary
+        // (https://gitlab.gnome.org/GNOME/mutter/commit/8655bc5d8de6a969e0ca83eff8e450f62d28fbee)
+        int x_start = reference_x;
+        if (x_start < 2) {
+            x_start = 2;
+        }
+
+        int y_start = reference_y;
+        if (y_start < 2) {
+            y_start = 2;
+        }
+
+        // For the same reason as above, we need to not use the bottom and right
+        // 2px of the texture. However, if the caller has specified an area of
+        // interest that already misses these parts, use that instead, otherwise
+        // chop 2px
+        int width = int.min (bg_actor_width - 2 - reference_x, reference_width);
+        int height = int.min (bg_actor_height - 2 - reference_y, reference_height);
+
+        if (x_start > bg_actor_width || y_start > bg_actor_height || width <= 0 || height <= 0) {
+            throw new DBusError.INVALID_ARGS ("Invalid rectangle specified: %i, %i, %i, %i".printf (x_start, y_start, width, height));
+        }
+
+        double mean_acutance = 0, variance = 0, mean = 0, r_total = 0, g_total = 0, b_total = 0;
+        ulong paint_signal_handler = 0;
+
+        paint_signal_handler = effect.done_painting.connect (() => {
+            SignalHandler.disconnect (effect, paint_signal_handler);
+            background.remove_effect (effect);
+
+            var texture = (Cogl.Texture)effect.get_texture ();
+            var texture_width = texture.get_width ();
+            var texture_height = texture.get_height ();
+
+            var pixels = new uint8[texture_width * texture_height * 4];
+            var pixel_lums = new double[texture_width * texture_height];
+
+            texture.get_data (Cogl.PixelFormat.BGRA_8888_PRE, 0, pixels);
+
+            int size = width * height;
+
+            double mean_squares = 0;
+            double pixel = 0;
+
+            double max, min, score, delta, score_total = 0, r_total2 = 0, g_total2 = 0, b_total2 = 0;
+
+            /*
+             * code to calculate weighted average color is copied from
+             * plank's lib/Drawing/DrawingService.vala average_color()
+             * http://bazaar.launchpad.net/~docky-core/plank/trunk/view/head:/lib/Drawing/DrawingService.vala
+             */
+            for (int y = y_start; y < (y_start + height); y++) {
+                for (int x = x_start; x < (x_start + width); x++) {
+                    int i = (y * (int)texture_width * 4) + (x * 4);
+
+                    uint8 b = pixels[i];
+                    uint8 g = pixels[i + 1];
+                    uint8 r = pixels[i + 2];
+
+                    pixel = (0.3 * r + 0.59 * g + 0.11 * b) ;
+
+                    pixel_lums[y * width + x] = pixel;
+
+                    min = uint8.min (r, uint8.min (g, b));
+                    max = uint8.max (r, uint8.max (g, b));
+
+                    delta = max - min;
+
+                    /* prefer colored pixels over shades of grey */
+                    score = SATURATION_WEIGHT * (delta == 0 ? 0.0 : delta / max);
+
+                    r_total += score * r;
+                    g_total += score * g;
+                    b_total += score * b;
+                    score_total += score;
+
+                    r_total += r;
+                    g_total += g;
+                    b_total += b;
+
+                    mean += pixel;
+                    mean_squares += pixel * pixel;
+                }
+            }
+
+            for (int y = y_start + 1; y < (y_start + height) - 1; y++) {
+                for (int x = x_start + 1; x < (x_start + width) - 1; x++) {
+                    var acutance =
+                        (pixel_lums[y * width + x] * 4) -
+                        (
+                            pixel_lums[y * width + x - 1] +
+                            pixel_lums[y * width + x + 1] +
+                            pixel_lums[(y - 1) * width + x] +
+                            pixel_lums[(y + 1) * width + x]
+                        );
+
+                    mean_acutance += acutance > 0 ? acutance : -acutance;
+                }
+            }
+
+            score_total /= size;
+            b_total /= size;
+            g_total /= size;
+            r_total /= size;
+
+            if (score_total > 0.0) {
+                b_total /= score_total;
+                g_total /= score_total;
+                r_total /= score_total;
+            }
+
+            b_total2 /= size * uint8.MAX;
+            g_total2 /= size * uint8.MAX;
+            r_total2 /= size * uint8.MAX;
+
+            /*
+             * combine weighted and not weighted sum depending on the average "saturation"
+             * if saturation isn't reasonable enough
+             * s = 0.0 -> f = 0.0 ; s = WEIGHT_THRESHOLD -> f = 1.0
+             */
+            if (score_total <= WEIGHT_THRESHOLD) {
+                var f = 1.0 / WEIGHT_THRESHOLD * score_total;
+                var rf = 1.0 - f;
+
+                b_total = b_total * f + b_total2 * rf;
+                g_total = g_total * f + g_total2 * rf;
+                r_total = r_total * f + r_total2 * rf;
+            }
+
+            /* there shouldn't be values larger then 1.0 */
+            var max_val = double.max (r_total, double.max (g_total, b_total));
+
+            if (max_val > 1.0) {
+                b_total /= max_val;
+                g_total /= max_val;
+                r_total /= max_val;
+            }
+
+            mean /= size;
+            mean_squares = mean_squares / size;
+
+            variance = (mean_squares - (mean * mean));
+
+            mean_acutance /= (width - 2) * (height - 2);
+
+            get_background_color_information.callback ();
+        });
+
+        background.queue_redraw ();
+
+        yield;
+
+        return { r_total, g_total, b_total, mean, variance, mean_acutance };
+    }
+
+}

--- a/compositor/DBusBackgroundManager.vala
+++ b/compositor/DBusBackgroundManager.vala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011-2015 Wingpanel Developers (http://launchpad.net/wingpanel)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+ [DBus (name = "org.pantheon.gala.WingpanelInterface")]
+ public class GreeterCompositor.DBusBackgroundManager : Object {
+     private BackgroundManager background_manager;
+     private static DBusBackgroundManager? instance;
+     static WindowManager wm;
+
+    [DBus (visible = false)]
+    public static void init (WindowManager _wm) {
+        wm = _wm;
+
+        Bus.own_name (BusType.SESSION, "org.pantheon.gala.WingpanelInterface", BusNameOwnerFlags.NONE,
+            (connection) => {
+                if (instance == null)
+                    instance = new DBusBackgroundManager ();
+
+                try {
+                    connection.register_object ("/org/pantheon/gala/WingpanelInterface", instance);
+                } catch (Error e) {
+                    warning (e.message);
+                }
+            },
+            () => {},
+            () => warning ("Could not acquire name\n")
+        );
+    }
+
+     public signal void state_changed (BackgroundState state, uint animation_duration);
+
+     public void initialize (int monitor, int panel_height) throws GLib.Error {
+         background_manager = new BackgroundManager (wm, panel_height);
+         background_manager.state_changed.connect ((state, animation_duration) => {
+             state_changed (state, animation_duration);
+         });
+     }
+
+     public bool begin_grab_focused_window (int x, int y, int button, uint time, uint state) throws GLib.Error {
+         return false;
+     }
+
+     public void remember_focused_window () throws GLib.Error {}
+     public void restore_focused_window () throws GLib.Error {}
+ }

--- a/compositor/SystemBackground.vala
+++ b/compositor/SystemBackground.vala
@@ -19,7 +19,7 @@
  * Authors: Corentin Noël <corentin@elementary.io>
  */
 
-    public class Greeter.SystemBackground : GLib.Object {
+public class Greeter.SystemBackground : GLib.Object {
     const Clutter.Color DEFAULT_BACKGROUND_COLOR = { 0x2e, 0x34, 0x36, 0xff };
 
     static Meta.Background? system_background = null;

--- a/compositor/WindowManager.vala
+++ b/compositor/WindowManager.vala
@@ -52,6 +52,8 @@ namespace GreeterCompositor {
          */
         public Meta.BackgroundGroup background_group { get; protected set; }
 
+        public Greeter.SystemBackground system_background { get; private set; }
+
         Meta.PluginInfo info;
 
         //WindowSwitcher? winswitcher = null;
@@ -88,7 +90,12 @@ namespace GreeterCompositor {
 
         void refresh_background () {
             unowned Meta.Display display = get_display ();
-            var system_background = new Greeter.SystemBackground (display);
+
+            stage.remove_child (system_background.background_actor);
+            system_background = new Greeter.SystemBackground (display);
+            system_background.background_actor.add_constraint (new Clutter.BindConstraint (stage,
+                Clutter.BindCoordinate.ALL, 0));
+            stage.insert_child_below (system_background.background_actor, null);
 
             system_background.refresh ();
         }
@@ -98,11 +105,12 @@ namespace GreeterCompositor {
             MediaFeedback.init ();
             DBus.init (this);
             DBusAccelerator.init (this);
+            DBusBackgroundManager.init (this);
             KeyboardManager.init (display);
 
             stage = display.get_stage () as Clutter.Stage;
 
-            var system_background = new Greeter.SystemBackground (display);
+            system_background = new Greeter.SystemBackground (display);
             system_background.background_actor.add_constraint (new Clutter.BindConstraint (stage,
                 Clutter.BindCoordinate.ALL, 0));
             stage.insert_child_below (system_background.background_actor, null);

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -77,8 +77,11 @@ mutter_typelib_dir = libmutter_dep.get_pkgconfig_variable('typelibdir')
 
 # Here is the real Compositor work
 compositor_files = files(
-  'DBusAccelerator.vala',
+  'BackgroundManager.vala',
+  'BackgroundUtils.vala',
   'DBus.vala',
+  'DBusAccelerator.vala',
+  'DBusBackgroundManager.vala',
   'KeyboardManager.vala',
   'main.vala',
   'MediaFeedback.vala',


### PR DESCRIPTION
Allows the compositor to tell Wingpanel about the colour of the background so it can adapt its transparency, as it does under Gala.

This code is 99% directly copied from the Gala plugin, so I haven't updated any of the copyright headers.