### PR TITLE
Add Lightdm conf dir to Install

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,7 @@
 etc/lightdm
 usr/bin
 usr/sbin
+usr/share/lightdm/lightdm.conf.d
 usr/share/locale
 usr/share/metainfo
 usr/share/xgreeters


### PR DESCRIPTION
We still need to make sure this package installs files to this directory because the latest package just doesn't install this file at all.