### PR TITLE
Improve handling of users' accent color

### DIFF
--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -290,7 +290,7 @@ public class Greeter.UserCard : Greeter.BaseCard {
             }
         });
 
-        update_style ();
+        // initially update_style is called inside `set_settings`
         notify["prefers-accent-color"].connect (() => {
             update_style ();
         });
@@ -301,12 +301,8 @@ public class Greeter.UserCard : Greeter.BaseCard {
     }
 
     private void update_style () {
-        var gtksettings = Gtk.Settings.get_default ();
-        gtksettings.gtk_theme_name = "io.elementary.stylesheet." + accent_to_string (prefers_accent_color);
-
-        var style_provider = Gtk.CssProvider.get_named (gtksettings.gtk_theme_name, null);
-        logged_in_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        password_entry_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        var interface_settings = new GLib.Settings ("org.gnome.desktop.interface");
+        interface_settings.set_value ("gtk-theme", "io.elementary.stylesheet." + accent_to_string (prefers_accent_color));
     }
 
     private string accent_to_string (int i) {
@@ -423,6 +419,7 @@ public class Greeter.UserCard : Greeter.BaseCard {
 
         set_keyboard_layouts ();
         set_mouse_touchpad_settings ();
+        update_style ();
     }
 
     private void set_keyboard_layouts () {

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -305,6 +305,12 @@ public class Greeter.UserCard : Greeter.BaseCard {
         interface_settings.set_value ("gtk-theme", "io.elementary.stylesheet." + accent_to_string (prefers_accent_color));
     }
 
+    private void set_check_style () {
+        // Override check's accent_color so that it *always* uses user's preferred color
+        var style_provider = Gtk.CssProvider.get_named ("io.elementary.stylesheet." + accent_to_string (prefers_accent_color), null);
+        logged_in_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+    }
+
     private string accent_to_string (int i) {
         switch (i) {
             case 1:
@@ -374,6 +380,8 @@ public class Greeter.UserCard : Greeter.BaseCard {
                 critical (e.message);
             }
         }
+
+        set_check_style ();
 
         if (needs_settings_set) {
             set_settings ();

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -290,11 +290,6 @@ public class Greeter.UserCard : Greeter.BaseCard {
             }
         });
 
-        // initially update_style is called inside `set_settings`
-        notify["prefers-accent-color"].connect (() => {
-            update_style ();
-        });
-
         grab_focus.connect (() => {
             password_entry.grab_focus_without_selecting ();
         });

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -28,6 +28,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
     private Hdy.Carousel carousel;
     private LightDM.Greeter lightdm_greeter;
     private Greeter.Settings settings;
+    private Gtk.Button guest_login_button;
     private Gtk.ToggleButton manual_login_button;
     private Greeter.DateTimeWidget datetime_widget;
     private unowned Greeter.BaseCard current_card;
@@ -60,7 +61,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
 
         set_visual (get_screen ().get_rgba_visual ());
 
-        var guest_login_button = new Gtk.Button.with_label (_("Log in as Guest"));
+        guest_login_button = new Gtk.Button.with_label (_("Log in as Guest"));
 
         manual_login_button = new Gtk.ToggleButton.with_label (_("Manual Login…"));
 
@@ -70,15 +71,9 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         extra_login_grid.column_spacing = 12;
         extra_login_grid.column_homogeneous = true;
 
-        try {
-            var gtksettings = Gtk.Settings.get_default ();
-            gtksettings.gtk_icon_theme_name = "elementary";
-            gtksettings.gtk_theme_name = "io.elementary.stylesheet.blueberry";
-
-            var css_provider = Gtk.CssProvider.get_named (gtksettings.gtk_theme_name, "dark");
-            guest_login_button.get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-            manual_login_button.get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        } catch (Error e) {}
+        update_style ();
+        unowned var gtk_settings = Gtk.Settings.get_default ();
+        gtk_settings.notify["gtk-theme-name"].connect (update_style);
 
         datetime_widget = new Greeter.DateTimeWidget ();
         datetime_widget.halign = Gtk.Align.CENTER;
@@ -277,6 +272,13 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
                 warning ("Unable to spawn numlockx to set numlock state");
             }
         }
+    }
+
+    private void update_style () {
+        unowned var gtksettings = Gtk.Settings.get_default ();
+        unowned var css_provider = Gtk.CssProvider.get_named (gtksettings.gtk_theme_name, "dark");
+        guest_login_button.get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        manual_login_button.get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 
     private void maximize_and_focus () {


### PR DESCRIPTION
* Set user's accent color globally using `org.gnome.desktop.interface gtk-theme`
* Style each user's check individually
