### PR TITLE
Use user's interface settings

### DIFF
--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -49,10 +49,12 @@ public class Greeter.UserCard : Greeter.BaseCard {
 
     private bool needs_settings_set = false;
 
+    public Gtk.Label username_label;
+
     construct {
         need_password = true;
 
-        var username_label = new Gtk.Label (lightdm_user.display_name) {
+        username_label = new Gtk.Label (lightdm_user.display_name) {
             hexpand = true,
             margin = 24,
             margin_bottom = 12
@@ -422,6 +424,7 @@ public class Greeter.UserCard : Greeter.BaseCard {
 
         set_keyboard_layouts ();
         set_mouse_touchpad_settings ();
+        set_interface_settings ();
         update_style ();
     }
 
@@ -466,9 +469,18 @@ public class Greeter.UserCard : Greeter.BaseCard {
         touchpad_settings.set_double ("speed", settings_act.touchpad_speed);
         touchpad_settings.set_boolean ("tap-to-click", settings_act.touchpad_tap_to_click);
         touchpad_settings.set_boolean ("two-finger-scrolling-enabled", settings_act.touchpad_two_finger_scrolling);
+    }
 
+    private void set_interface_settings () {
         var interface_settings = new GLib.Settings ("org.gnome.desktop.interface");
-        interface_settings.set_int ("cursor-size", settings_act.cursor_size);
+        interface_settings.set_value ("cursor-blink", settings_act.cursor_blink);
+        interface_settings.set_value ("cursor-blink-time", settings_act.cursor_blink_time);
+        interface_settings.set_value ("cursor-blink-timeout", settings_act.cursor_blink_timeout);
+        interface_settings.set_value ("cursor-size", settings_act.cursor_size);
+        interface_settings.set_value ("locate-pointer", settings_act.locate_pointer);
+        interface_settings.set_value ("text-scaling-factor", settings_act.text_scaling_factor);
+
+        username_label.label = "%f".printf (settings_act.text_scaling_factor);
     }
 
     public UserCard (LightDM.User lightdm_user) {

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -49,12 +49,10 @@ public class Greeter.UserCard : Greeter.BaseCard {
 
     private bool needs_settings_set = false;
 
-    public Gtk.Label username_label;
-
     construct {
         need_password = true;
 
-        username_label = new Gtk.Label (lightdm_user.display_name) {
+        var username_label = new Gtk.Label (lightdm_user.display_name) {
             hexpand = true,
             margin = 24,
             margin_bottom = 12
@@ -479,8 +477,6 @@ public class Greeter.UserCard : Greeter.BaseCard {
         interface_settings.set_value ("cursor-size", settings_act.cursor_size);
         interface_settings.set_value ("locate-pointer", settings_act.locate_pointer);
         interface_settings.set_value ("text-scaling-factor", settings_act.text_scaling_factor);
-
-        username_label.label = "%f".printf (settings_act.text_scaling_factor);
     }
 
     public UserCard (LightDM.User lightdm_user) {

--- a/src/PantheonAccountsServicePlugin.vala
+++ b/src/PantheonAccountsServicePlugin.vala
@@ -43,5 +43,10 @@ interface Pantheon.SettingsDaemon.AccountsService : Object {
     public abstract bool touchpad_tap_to_click { get; set; }
     public abstract bool touchpad_two_finger_scrolling { get; set; }
 
+    public abstract bool cursor_blink { get; set; }
+    public abstract int cursor_blink_time { get; set; }
+    public abstract int cursor_blink_timeout { get; set; }
     public abstract int cursor_size { get; set; }
+    public abstract bool locate_pointer { get; set; }
+    public abstract double text_scaling_factor { get; set; }
 }


### PR DESCRIPTION
Sets user cursor blinking settings, cursor size, text size and option to locate the pointer (~doesn't work yet because it requires implementation in compositor~ #674)

Requires https://github.com/elementary/settings-daemon/pull/71

Fixes https://github.com/elementary/greeter/issues/596