### PR TITLE
ci: Specify the mutter package to use

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         version: [stable, unstable, development-target]
+        include:
+          - version: stable
+            mutter_pkg: libmutter-10-dev
+          - version: unstable
+            mutter_pkg: libmutter-10-dev
+          - version: development-target
+            mutter_pkg: libmutter-13-dev
     container:
       image: ghcr.io/elementary/docker:${{ matrix.version }}
 
@@ -24,7 +31,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y desktop-file-utils libaccountsservice-dev libclutter-gtk-1.0-dev libgdk-pixbuf2.0-dev libgranite-dev libgtk-3-dev libhandy-1-dev liblightdm-gobject-1-dev libx11-dev meson libmutter-*-dev libgnome-desktop-3-dev valac
+        apt install -y desktop-file-utils libaccountsservice-dev libclutter-gtk-1.0-dev libgdk-pixbuf2.0-dev libgranite-dev libgtk-3-dev libhandy-1-dev liblightdm-gobject-1-dev libx11-dev meson ${{ matrix.mutter_pkg }} libgnome-desktop-3-dev valac
     - name: Build
       env:
         DESTDIR: out


### PR DESCRIPTION
This allows us to specify the mutter version instead of using globs (useful as some Ubuntu version have two mutter version in the repository while transitioning to the next version)