### PR TITLE
Make datetime widget larger

### DIFF
--- a/data/DateTime.css
+++ b/data/DateTime.css
@@ -1,19 +1,24 @@
 .date,
 .time {
     color: #fff;
-    text-shadow:
-        0 1px 1px alpha (#000, 0.3),
-        -1px 1px 1px alpha (#000, 0.15),
-        1px 1px 1px alpha (#000, 0.15),
-        0 2px 1px alpha (#000, 0.05),
-        -2px 2px 1px alpha (#000, 0.05),
-        2px 2px 1px alpha (#000, 0.05);
 }
 
 .date {
-    font-size: 24px;
+    font-size: 2em;
+    font-weight: 600;
+    margin-top: -0.5em;
+    opacity: 0.9;
+    text-shadow:
+        0 1px 2px alpha(black, 0.4),
+        0 1px 3px alpha(black, 0.1);
 }
 
 .time {
-    font-size: 72px;
+    font-feature-settings: "cv01";
+    font-size: 10em;
+    font-weight: 500;
+    letter-spacing: -0.05em;
+    text-shadow:
+        0 1px 2px alpha(black, 0.3),
+        0 3px 6px alpha(black, 0.15);
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -81,6 +81,7 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
         datetime_revealer = new Gtk.Revealer () {
             child = datetime_widget,
             transition_type = CROSSFADE,
+            valign = CENTER,
             vexpand = true
         };
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -68,18 +68,20 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
 
         manual_login_button = new Gtk.ToggleButton.with_label (_("Manual Login…"));
 
-        var extra_login_grid = new Gtk.Grid ();
-        extra_login_grid.halign = Gtk.Align.CENTER;
-        extra_login_grid.valign = Gtk.Align.END;
-        extra_login_grid.column_spacing = 12;
-        extra_login_grid.column_homogeneous = true;
+        var extra_login_grid = new Gtk.Grid () {
+            column_homogeneous = true,
+            column_spacing = 12,
+            halign = CENTER,
+            valign = END,
+            vexpand = true
+        };
 
         datetime_widget = new Greeter.DateTimeWidget ();
 
         datetime_revealer = new Gtk.Revealer () {
-            halign = CENTER,
             child = datetime_widget,
-            transition_type = CROSSFADE
+            transition_type = CROSSFADE,
+            vexpand = true
         };
 
         user_cards = new GLib.Queue<unowned Greeter.UserCard> ();

--- a/src/Widgets/DateTimeWidget.vala
+++ b/src/Widgets/DateTimeWidget.vala
@@ -19,12 +19,9 @@ public class Greeter.DateTimeWidget : Gtk.Box {
         Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         time_label = new Gtk.Label (null);
-        time_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
         time_label.get_style_context ().add_class ("time");
 
-
         date_label = new Gtk.Label (null);
-        date_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
         date_label.get_style_context ().add_class ("date");
 
         orientation = VERTICAL;


### PR DESCRIPTION
Make the datetime widget larger, bolder, with softer shadows, and more towards the center of the display

## AFTER
![Screenshot from 2024-05-16 13 35 25](https://github.com/elementary/greeter/assets/7277719/f85278a7-9456-4fa9-95c3-ee5aeb02c27a)

## BEFORE
![Screenshot from 2024-05-16 13 38 02](https://github.com/elementary/greeter/assets/7277719/d2a9d9de-7b96-4005-a65d-637057796609)
