### PR TITLE
Compositor: only set current desktop on greeter

### DIFF
--- a/compositor/main.vala
+++ b/compositor/main.vala
@@ -28,9 +28,11 @@ namespace GreeterCompositor {
     }
 
     public static int main (string[] args) {
-        // Ensure we present ourselves as Pantheon so we pick up the right GSettings
-        // overrides
-        GLib.Environment.set_variable ("XDG_CURRENT_DESKTOP", "Pantheon", true);
+        if (GLib.Environment.get_variable ("DESKTOP_SESSION") != "installer") {
+            // Ensure we present ourselves as Pantheon so we pick up the right GSettings
+            // overrides
+            GLib.Environment.set_variable ("XDG_CURRENT_DESKTOP", "Pantheon", true);
+        }
 
         var settings_daemon = new SettingsDaemon ();
         settings_daemon.start ();


### PR DESCRIPTION
Don't set `XDG_CURRENT_DESKTOP` in the installer session. Installer has its own overrides