### PR TITLE
Add dark style support

### DIFF
--- a/compositor/WindowManager.vala
+++ b/compositor/WindowManager.vala
@@ -223,6 +223,7 @@ namespace GreeterCompositor {
                 if (GLib.Environment.get_variable ("DESKTOP_SESSION") != "installer") {
                     start_command.begin ({ "io.elementary.greeter-session-manager" });
                     start_command.begin ({ "io.elementary.greeter" });
+                    start_command.begin ({ "io.elementary.settings-daemon" });
                 }
 
                 return GLib.Source.REMOVE;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -41,6 +41,30 @@ public class Greeter.Application : Gtk.Application {
         css_provider.load_from_resource ("/io/elementary/greeter/Application.css");
 
         Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        GLib.Bus.own_name (
+            SESSION,
+            "org.freedesktop.portal.Desktop",
+            NONE,
+            (connection, name) => {
+                try {
+                    connection.register_object ("/org/freedesktop/portal/desktop", SettingsPortal.get_default ());
+                } catch (Error e) {
+                    critical ("Unable to register the object: %s", e.message);
+                }
+            },
+            () => debug ("org.freedesktop.portal.Desktop acquired"),
+            () => debug ("org.freedesktop.portal.Desktop lost")
+        );
+
+        unowned var gtk_settings = Gtk.Settings.get_default ();
+        unowned var settings_portal = SettingsPortal.get_default ();
+
+        gtk_settings.gtk_application_prefer_dark_theme = settings_portal.prefers_color_scheme == 1;
+
+        settings_portal.notify["prefers-color-scheme"].connect (() => {
+            gtk_settings.gtk_application_prefer_dark_theme = settings_portal.prefers_color_scheme == 1;
+        });
     }
 
     public override void activate () {

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -232,6 +232,10 @@ public class Greeter.UserCard : Greeter.BaseCard {
 
         notify["show-input"].connect (() => {
             update_collapsed_class ();
+
+            if (greeter_act != null) {
+                SettingsPortal.get_default ().prefers_color_scheme = greeter_act.prefers_color_scheme;
+            }
         });
 
         password_entry.activate.connect (on_login);
@@ -336,6 +340,10 @@ public class Greeter.UserCard : Greeter.BaseCard {
                 sleep_inactive_battery_timeout = greeter_act.sleep_inactive_battery_timeout;
                 sleep_inactive_battery_type = greeter_act.sleep_inactive_battery_type;
 
+                if (show_input) {
+                    SettingsPortal.get_default ().prefers_color_scheme = greeter_act.prefers_color_scheme;
+                }
+
                 ((DBusProxy) greeter_act).g_properties_changed.connect ((changed_properties, invalidated_properties) => {
                     string time_format;
                     changed_properties.lookup ("TimeFormat", "s", out time_format);
@@ -346,6 +354,10 @@ public class Greeter.UserCard : Greeter.BaseCard {
                     changed_properties.lookup ("SleepInactiveACType", "i", out _sleep_inactive_ac_type);
                     changed_properties.lookup ("SleepInactiveBatteryTimeout", "i", out _sleep_inactive_battery_timeout);
                     changed_properties.lookup ("SleepInactiveBatteryType", "i", out _sleep_inactive_battery_type);
+
+                    if (show_input) {
+                        SettingsPortal.get_default ().prefers_color_scheme = greeter_act.prefers_color_scheme;
+                    }
                 });
             } catch (Error e) {
                 critical (e.message);

--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -483,6 +483,17 @@ public class Greeter.UserCard : Greeter.BaseCard {
         set_or_reset_settings_key (interface_settings, "font-name", settings_act.font_name);
         set_or_reset_settings_key (interface_settings, "monospace-font-name", settings_act.monospace_font_name);
 
+        var settings_daemon_settings = new GLib.Settings ("io.elementary.settings-daemon.prefers-color-scheme");
+
+        var latitude = new Variant.double (settings_act.last_coordinates.latitude);
+        var longitude = new Variant.double (settings_act.last_coordinates.longitude);
+        var coordinates = new Variant.tuple ({latitude, longitude});
+        settings_daemon_settings.set_value ("last-coordinates", coordinates);
+
+        settings_daemon_settings.set_enum ("prefer-dark-schedule", settings_act.prefer_dark_schedule);
+        settings_daemon_settings.set_value ("prefer-dark-schedule-from", settings_act.prefer_dark_schedule_from);
+        settings_daemon_settings.set_value ("prefer-dark-schedule-to", settings_act.prefer_dark_schedule_to);
+
         var touchscreen_settings = new GLib.Settings ("org.gnome.settings-daemon.peripherals.touchscreen");
         touchscreen_settings.set_boolean ("orientation-lock", settings_act.orientation_lock);
 
@@ -501,8 +512,8 @@ public class Greeter.UserCard : Greeter.BaseCard {
         var night_light_settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.color");
         night_light_settings.set_value ("night-light-enabled", settings_act.night_light_enabled);
 
-        var latitude = new Variant.double (settings_act.night_light_last_coordinates.latitude);
-        var longitude = new Variant.double (settings_act.night_light_last_coordinates.longitude);
+        var latitude = new Variant.double (settings_act.last_coordinates.latitude);
+        var longitude = new Variant.double (settings_act.last_coordinates.longitude);
         var coordinates = new Variant.tuple ({latitude, longitude});
         night_light_settings.set_value ("night-light-last-coordinates", coordinates);
 

--- a/src/PantheonAccountsServicePlugin.vala
+++ b/src/PantheonAccountsServicePlugin.vala
@@ -16,6 +16,11 @@ interface Pantheon.AccountsService : Object {
 
 [DBus (name = "io.elementary.SettingsDaemon.AccountsService")]
 interface Pantheon.SettingsDaemon.AccountsService : Object {
+    public struct Coordinates {
+        public double latitude;
+        public double longitude;
+    }
+
     /* Keyboard */
     public struct KeyboardLayout {
         public string backend;
@@ -60,14 +65,15 @@ interface Pantheon.SettingsDaemon.AccountsService : Object {
     public abstract string monospace_font_name { owned get; set; }
     public abstract bool orientation_lock { get; set; }
 
-    /* Night Light */
-    public struct Coordinates {
-        public double latitude;
-        public double longitude;
-    }
+    /* Prefer Dark Schedule (part of interface settings)*/
+    /* Last coordinates are reused for Night Light settings */
+    public abstract Coordinates last_coordinates { get; set; }
+    public abstract int prefer_dark_schedule { get; set; }
+    public abstract double prefer_dark_schedule_from { get; set; }
+    public abstract double prefer_dark_schedule_to { get; set; }
 
+    /* Night Light */
     public abstract bool night_light_enabled { get; set; }
-    public abstract Coordinates night_light_last_coordinates { get; set; }
     public abstract bool night_light_schedule_automatic { get; set; }
     public abstract double night_light_schedule_from { get; set; }
     public abstract double night_light_schedule_to { get; set; }

--- a/src/PantheonAccountsServicePlugin.vala
+++ b/src/PantheonAccountsServicePlugin.vala
@@ -2,6 +2,7 @@
 interface Pantheon.AccountsService : Object {
     public abstract string time_format { owned get; set; }
 
+    public abstract int prefers_color_scheme { get; set; }
     public abstract int prefers_accent_color { get; set; }
 
     [DBus (name = "SleepInactiveACTimeout")]

--- a/src/SettingsPortal.vala
+++ b/src/SettingsPortal.vala
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ */
+
+[DBus (name = "org.freedesktop.portal.Error")]
+public errordomain Greeter.PortalError {
+    FAILED,
+    INVALID_ARGUMENT,
+    NOT_FOUND,
+    EXISTS,
+    NOT_ALLOWED,
+    CANCELLED,
+    WINDOW_DESTROYED
+}
+
+[DBus (name = "org.freedesktop.portal.Settings")]
+public class Greeter.SettingsPortal : Object {
+    private static GLib.Once<SettingsPortal> instance;
+    public static unowned SettingsPortal get_default () {
+        return instance.once (() => {
+            return new SettingsPortal ();
+        });
+    }
+
+    private SettingsPortal () {}
+
+    public signal void setting_changed (string namespace, string key, GLib.Variant value);
+
+    private int _prefers_color_scheme = 0;
+    public int prefers_color_scheme {
+        get {
+            return _prefers_color_scheme;
+        }
+        set {
+            _prefers_color_scheme = value;
+            setting_changed ("org.freedesktop.appearance", "color-scheme", new GLib.Variant.uint32 (prefers_color_scheme));
+        }
+    }
+
+    public async GLib.HashTable<string, GLib.HashTable<string, GLib.Variant>> read_all (string[] namespaces) throws GLib.DBusError, GLib.IOError {
+        var dict = new GLib.HashTable<string, GLib.Variant> (str_hash, str_equal);
+        dict.insert ("color-scheme", new GLib.Variant.uint32 (prefers_color_scheme));
+
+        var ret = new GLib.HashTable<string, GLib.HashTable<string, GLib.Variant>> (str_hash, str_equal);
+        ret.insert ("org.freedesktop.appearance", dict);
+
+        return ret;
+    }
+
+    public async GLib.Variant read (string namespace, string key) throws GLib.DBusError, GLib.Error {
+        if (namespace == "org.freedesktop.appearance" && key == "color-scheme") {
+            return new GLib.Variant.uint32 (prefers_color_scheme);
+        }
+
+        throw new PortalError.NOT_FOUND ("Requested setting not found");
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ executable(
     'PantheonAccountsServicePlugin.vala',
     'PromptText.vala',
     'Settings.vala',
+    'SettingsPortal.vala',
     'Cards/BaseCard.vala',
     'Cards/ManualCard.vala',
     'Cards/UserCard.vala',


### PR DESCRIPTION
Fixes https://github.com/elementary/greeter/issues/688
Closes #563
Closes #499

This branch implements mini settings portal inside of the greeter itself and exposes it via dbus which allows granite to correctly get dark style preference