### PR TITLE
Select classic session when using a11y features

### DIFF
--- a/data/io.elementary.greeter.desktop.in
+++ b/data/io.elementary.greeter.desktop.in
@@ -1,5 +1,7 @@
 [Desktop Entry]
 Name=Pantheon Greeter
 Comment=Pantheon Greeter
+Icon=io.elementary.settings
 Exec=@PROJECT_NAME@-compositor
 Type=Application
+NoDisplay=true

--- a/data/meson.build
+++ b/data/meson.build
@@ -25,6 +25,12 @@ i18n.merge_file(
     install_dir: get_option('datadir') / 'metainfo',
 )
 
+# For notifications
+install_data(
+    desktop_in,
+    install_dir: get_option('datadir') / 'applications',
+)
+
 install_data(
     meson.project_name() + '.conf',
     install_dir: join_paths(get_option('sysconfdir'), 'lightdm')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -102,6 +102,29 @@ public class Greeter.Application : Gtk.Application {
         });
 
         add_action (select_session_action);
+
+        var a11y_settings = new GLib.Settings ("org.gnome.desktop.a11y.applications");
+        a11y_settings.changed.connect ((key) => {
+            if (key != "screen-keyboard-enabled" && key != "screen-reader-enabled") {
+                return;
+            }
+
+            if (!a11y_settings.get_boolean (key)) {
+                return;
+            }
+
+            if (select_session_action.get_state ().get_string () != "pantheon-wayland") {
+                return;
+            }
+
+            select_session_action.set_state (new Variant.string ("pantheon"));
+
+            var notification = new Notification (_("Classic session automatically selected"));
+            notification.set_body (_("Accessibility features may be unavailable in the Secure session"));
+            notification.set_icon (new ThemedIcon ("preferences-desktop-accessibility"));
+
+            send_notification ("session-type", notification);
+        });
     }
 
     public override void activate () {


### PR DESCRIPTION
Fixes #818

Pre-req of #747 

If the secure session is selected and one of the a11y options is enabled, switch to the secure session and notify. 