### PR TITLE
ShellClientsManager: centered windows are not always shell windows

### DIFF
--- a/compositor/ShellClients/ShellClientsManager.vala
+++ b/compositor/ShellClients/ShellClientsManager.vala
@@ -191,7 +191,6 @@ public class GreeterCompositor.ShellClientsManager : Object {
 
     public bool is_itself_shell_window (Meta.Window window) {
         return (
-            (window in positioned_windows && positioned_windows[window].modal) ||
             (window in panel_windows) ||
             NotificationStack.is_notification (window)
         );

--- a/compositor/ShellClients/ShellWindow.vala
+++ b/compositor/ShellClients/ShellWindow.vala
@@ -6,9 +6,6 @@
  */
 
 public class GreeterCompositor.ShellWindow : PositionedWindow {
-    public bool modal { get; private set; default = false; }
-    public bool dim { get; private set; default = false; }
-
     public Clutter.Actor? actor { get { return window_actor; } }
 
     private Meta.WindowActor window_actor;
@@ -24,11 +21,6 @@ public class GreeterCompositor.ShellWindow : PositionedWindow {
         window_actor.notify["height"].connect (update_clip);
         window_actor.notify["translation-y"].connect (update_clip);
         notify["position"].connect (update_clip);
-    }
-
-    public void make_modal (bool dim) {
-        modal = true;
-        this.dim = dim;
     }
 
     private void update_clip () {


### PR DESCRIPTION
Fixes #https://github.com/elementary/installer/issues/917

Based on changes from https://github.com/elementary/gala/pull/2709

It looks like Greeter Compositor isn't currently using `ExtendedBehaviorWindow`. It would create a pretty large diff to add that here, so workaround that for now by just adding modal/dim function/property to ShellWindow