### PR TITLE
Remove numlockx dependency

### DIFF
--- a/data/io.elementary.greeter.conf
+++ b/data/io.elementary.greeter.conf
@@ -1,2 +1,1 @@
 [greeter]
-#activate-numlock=true

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -184,14 +184,6 @@ public class Greeter.MainWindow : Gtk.ApplicationWindow {
 
         maximize ();
 
-        if (settings.activate_numlock) {
-            try {
-                Process.spawn_async (null, { "numlockx", "on" }, null, SpawnFlags.SEARCH_PATH, null, null);
-            } catch (Error e) {
-                warning ("Unable to spawn numlockx to set numlock state");
-            }
-        }
-
         main_box.realize.connect (init_panel);
     }
 

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -8,17 +8,6 @@
 public class Greeter.Settings : GLib.Object {
     private GLib.KeyFile settings;
 
-    public bool activate_numlock {
-        get {
-            try {
-                return settings.get_boolean ("greeter", "activate-numlock");
-            } catch (Error e) {
-                debug (e.message);
-                return false;
-            }
-        }
-    }
-
     construct {
         settings = new GLib.KeyFile ();
         try {


### PR DESCRIPTION
## Summary

- remove the X11-only `numlockx` startup invocation
- remove the now-unused `activate_numlock` setting
- remove the obsolete sample configuration key
- leave the Num Lock state indicator unchanged

## Why

`numlockx` only operates on X11. Keeping the external process invocation in the greeter leaves a dead and misleading configuration path as the project moves through its Wayland-capable startup flow. Removing the complete integration fixes the dependency at its source instead of suppressing spawn errors.

Fixes #898.

## Validation

- `git diff --check`
- verified there are no remaining `numlockx`, `activate_numlock`, or `activate-numlock` references under `src/` or `data/`
- `meson setup build` reached dependency resolution, then stopped because Homebrew does not provide a supported `wayland-scanner` bottle on this macOS host; the Linux CI build is required for full compilation

## AI disclosure

OpenAI Codex assisted with repository research, the focused edit, and validation. I reviewed the final diff before publishing.
