### PR TITLE
Hide session dropdown if only single session available

### DIFF
--- a/src/Cards/UserCard.vala
+++ b/src/Cards/UserCard.vala
@@ -54,14 +54,18 @@ public class Greeter.UserCard : Greeter.BaseCard {
             vexpand = true
         };
 
-        var password_grid = new Gtk.Grid () {
-            column_spacing = 6,
-            row_spacing = 6
-        };
-        password_grid.attach (password_entry, 0, 0);
-        password_grid.attach (fingerprint_image, 1, 0);
-        password_grid.attach (password_session_button, 2, 0);
-        password_grid.attach (new Greeter.CapsLockRevealer (), 0, 1, 3);
+        /*
+         * Combine two Gtk.Boxes instead of using one Gtk.Grid to avoid column_spacing becomes extra right margin
+         * when only password_entry is visible in the first row.
+         */
+        var password_hbox = new Gtk.Box (HORIZONTAL, 6);
+        password_hbox.append (password_entry);
+        password_hbox.append (fingerprint_image);
+        password_hbox.append (password_session_button);
+
+        var password_box = new Gtk.Box (VERTICAL, 6);
+        password_box.append (password_hbox);
+        password_box.append (new Greeter.CapsLockRevealer ());
 
         var login_button = new Gtk.Button.with_label (_("Log In"));
         login_button.add_css_class (Granite.CssClass.SUGGESTED);
@@ -89,7 +93,7 @@ public class Greeter.UserCard : Greeter.BaseCard {
             margin_start = 24,
             margin_end = 24
         };
-        login_stack.add_named (password_grid, "password");
+        login_stack.add_named (password_box, "password");
         login_stack.add_named (login_button, "button");
         login_stack.add_named (disabled_box, "disabled");
 

--- a/src/Widgets/SessionButton.vala
+++ b/src/Widgets/SessionButton.vala
@@ -24,6 +24,8 @@ public class Greeter.SessionButton : Granite.Bin {
             has_frame = false
         };
 
+        visible = iter.n_children () > 1;
+
         child = menu_button;
     }
 }


### PR DESCRIPTION
Fixes #904

Tested on OS 8 Daily where we have two sessions:

<img width="1280" height="800" alt="Screenshot_elementary-8-daily_2026-08-24_23:00:04" src="https://github.com/user-attachments/assets/a685e864-9fe5-4025-8933-5b1789895fca" />

after running `sudo rm /usr/share/xsessions/pantheon.desktop` and rebooting to make sure only Secure Session 
alive:

<img width="1280" height="800" alt="Screenshot_elementary-8-daily_2026-08-24_23:00:27" src="https://github.com/user-attachments/assets/41e65fd5-f893-47df-9e5a-71a50cce1dc8" />
